### PR TITLE
V0.54.1

### DIFF
--- a/src/HypoTestTool.cxx
+++ b/src/HypoTestTool.cxx
@@ -88,7 +88,7 @@ RooStats::HypoTestTool::HypoTestTool() : m_hc(0), m_calc(0),
     mOptimize(true),
     mUseVectorStore(true),
     mGenerateBinned(true),
-    mUseProof(false),
+    mUseProof(true),
     mEnableDetailedOutput(false),
     mRebuild(false),
     mNWorkers(4),
@@ -308,6 +308,15 @@ RooStats::HypoTestTool::RunHypoTestInverter(RooWorkspace * w,
     if (!ok) {
         return 0;
     }
+
+    ToyMCSampler *toymcs = (ToyMCSampler*)m_hc->GetTestStatSampler();
+    RooStats::ProofConfig * pc = nullptr;
+    //can speed up using proof-lite
+    if (mUseProof && mNWorkers > 1) {
+      pc = new RooStats::ProofConfig(*w, mNWorkers, "", kFALSE);
+      toymcs->SetProofConfig(pc);    // enable proof
+    }
+
 
     /// by now m_calc has been setup okay ...
     TStopwatch tw; 
@@ -792,12 +801,6 @@ RooStats::HypoTestTool::SetupHypoTestInverter(RooWorkspace * w,
     m_calc->UseCLs(useCLs);
     m_calc->SetVerbose(true);
 
-    // can speed up using proof-lite
-    if (mUseProof && mNWorkers > 1) { 
-        ToyMCSampler *toymcs = (ToyMCSampler*)m_hc->GetTestStatSampler();
-        ProofConfig pc(*w, mNWorkers, "", kFALSE);
-        toymcs->SetProofConfig(&pc);    // enable proof
-    }
 
     // get models from WS
     // get the modelConfig out of the file


### PR DESCRIPTION
In GitLab by @llongo on Jul 17, 2017, 03:23

Fixed the proof bug. Now proof is enable by default but it could be switched off changing the initial value of mUseProof (line 91) in src/HypoTestTool.cxx.