### PR TITLE
Compatibility with python2

### DIFF
--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -28,7 +28,7 @@ print("")
 
 import os
 import ROOT
-ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
+ROOT.gSystem.Load(os.getenv('HISTFITTER')+"/lib/libSusyFitter.so")
 
 ROOT.gROOT.SetBatch()
 

--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -28,7 +28,7 @@ print("")
 
 import os
 import ROOT
-ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
+gSystem.Load("libSusyFitter.so")
 
 ROOT.gROOT.SetBatch()
 

--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -28,7 +28,7 @@ print("")
 
 import os
 import ROOT
-gSystem.Load("libSusyFitter.so")
+ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
 
 ROOT.gROOT.SetBatch()
 


### PR DESCRIPTION
Hey,

If I'm not mistaken, the usage of f-strings starts from python 3.6, and it's not compatibile with python2 (HF v0.66.0)

Eric
@matthewfeickert 