### PR TITLE
fix: Harmonize scripts indented with tabs to spaces with rest of codebase

### DIFF
--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# GenerateJSONOutput.py #################
+# GenerateJSONOutput.py
 #
 # Command-line interface for turning output root files into JSON files for further processing.
 #
@@ -10,24 +10,60 @@
 import argparse, sys, os
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--inputFiles','-i', type=str, nargs='+', help="input ROOT files -- if you give me just the nominal, I'll try to find the theory variations and the upper limit automatically", required=True)
-parser.add_argument("--format","-f",          type=str, help="format of object names", default = "hypo_SU_%f_%f_0_10")
-parser.add_argument("--interpretation","-p",  type=str, help="interpretation of object name", default = "m0:m12")
-parser.add_argument("--addCoordinates","-a",  type=str, help="add additional coordinates to json using a python dictionary {existing json value name and math : new value name}", default = '{"m0":"x","m12":"y"}')
-parser.add_argument("--cut","-c",  type=str, help="cut string", default = "1")
-parser.add_argument("--noAddTabs","-n",  help = "don't convert JSON to human readable file", action="store_true", default=False)
+parser.add_argument(
+    "--inputFiles",
+    "-i",
+    type=str,
+    nargs="+",
+    help="input ROOT files -- if you give me just the nominal, I'll try to find the theory variations and the upper limit automatically",
+    required=True,
+)
+parser.add_argument(
+    "--format",
+    "-f",
+    type=str,
+    help="format of object names",
+    default="hypo_SU_%f_%f_0_10",
+)
+parser.add_argument(
+    "--interpretation",
+    "-p",
+    type=str,
+    help="interpretation of object name",
+    default="m0:m12",
+)
+parser.add_argument(
+    "--addCoordinates",
+    "-a",
+    type=str,
+    help="add additional coordinates to json using a python dictionary {existing json value name and math : new value name}",
+    default='{"m0":"x","m12":"y"}',
+)
+parser.add_argument("--cut", "-c", type=str, help="cut string", default="1")
+parser.add_argument(
+    "--noAddTabs",
+    "-n",
+    help="don't convert JSON to human readable file",
+    action="store_true",
+    default=False,
+)
 
 args = parser.parse_args()
 
 
 # Print out the settings
 for setting in dir(args):
-	if not setting[0]=="_":
-		print(">>> ... Setting: {: >20} {: >40}".format(setting, eval("args.%s"%setting) ))
+    if not setting[0] == "_":
+        print(
+            ">>> ... Setting: {: >20} {: >40}".format(
+                setting, eval("args.%s" % setting)
+            )
+        )
 print("")
 
 import os
 import ROOT
+
 ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
 
 ROOT.gROOT.SetBatch()
@@ -35,98 +71,126 @@ ROOT.gROOT.SetBatch()
 
 def main():
 
+    for filename in args.inputFiles:
 
-	for filename in args.inputFiles:
+        processFile(filename)
+        if args.addCoordinates != "":
+            addCoordinates(filename, args.addCoordinates)
 
-		processFile(filename)
-                if args.addCoordinates !="":  addCoordinates(filename, args.addCoordinates)
+        if "Nominal" in filename:
+            print(">>> Attempting to find theory variation files")
 
-		if "Nominal" in filename:
-			print(">>> Attempting to find theory variation files")
+            try:
+                newfilename = filename.replace("Nominal", "Up")
+                if newfilename == filename:
+                    raise
+                processFile(newfilename)
+                if args.addCoordinates != "":
+                    addCoordinates(newfilename, args.addCoordinates)
+            except:
+                print(
+                    ">>> WARNING: Can't find file: %s"
+                    % filename.replace("Nominal", "Up")
+                )
 
-			try:
-                                newfilename = filename.replace("Nominal","Up")
-                                if newfilename == filename: raise
-				processFile(newfilename)
-                                if args.addCoordinates !="":  addCoordinates(newfilename, args.addCoordinates)
-			except:
-				print(">>> WARNING: Can't find file: %s"%filename.replace("Nominal","Up"))
+            try:
+                newfilename = filename.replace("Nominal", "Down")
+                if newfilename == filename:
+                    raise
+                processFile(newfilename)
+                if args.addCoordinates != "":
+                    addCoordinates(newfilename, args.addCoordinates)
+            except:
+                print(
+                    ">>> WARNING: Can't find file: %s"
+                    % filename.replace("Nominal", "Down")
+                )
 
-			try:
-                                newfilename = filename.replace("Nominal","Down")
-                                if newfilename == filename: raise                                
-				processFile(newfilename)
-                                if args.addCoordinates !="":  addCoordinates(newfilename, args.addCoordinates)
-			except:
-				print(">>> WARNING: Can't find file: %s"%filename.replace("Nominal","Down"))
+            try:
+                newfilename = filename.replace(
+                    "_fixSigXSecNominal_hypotest", "_upperlimit"
+                )
+                if newfilename == filename:
+                    raise
+                processFile(newfilename)
+                if args.addCoordinates != "":
+                    addCoordinates(newfilename, args.addCoordinates)
+            except:
+                print(
+                    ">>> WARNING: Can't find file: %s"
+                    % filename.replace("_fixSigXSecNominal_hypotest", "_upperlimit")
+                )
+            try:
+                newfilename = filename.replace("_Nominal", "_upperlimit")
+                if newfilename == filename:
+                    raise
+                processFile(newfilename)
+                if args.addCoordinates != "":
+                    addCoordinates(newfilename, args.addCoordinates)
+            except:
+                print(
+                    ">>> WARNING: Can't find file: %s"
+                    % filename.replace("_fixSigXSecNominal_hypotest", "_upperlimit")
+                )
 
-			try:
-                                newfilename = filename.replace("_fixSigXSecNominal_hypotest","_upperlimit")
-                                if newfilename == filename: raise                                
-				processFile(newfilename)
-                                if args.addCoordinates !="":  addCoordinates(newfilename, args.addCoordinates)
-			except:
-				print(">>> WARNING: Can't find file: %s"%filename.replace("_fixSigXSecNominal_hypotest","_upperlimit"))
-			try:
-                                newfilename = filename.replace("_Nominal","_upperlimit")
-                                if newfilename == filename: raise
-				processFile(newfilename)
-                                if args.addCoordinates !="":  addCoordinates(newfilename, args.addCoordinates)
-			except:
-				print(">>> WARNING: Can't find file: %s"%filename.replace("_fixSigXSecNominal_hypotest","_upperlimit"))
+    if not args.noAddTabs:
+        cleanUpJSON()
 
-	if not args.noAddTabs:
-		cleanUpJSON()
+    print(">>>")
+    print(">>> Done!")
+    print(">>>")
 
-	print(">>>")
-	print(">>> Done!")
-	print(">>>")
+    return
 
-	return
 
 def processFile(file):
 
-	print("")
-	if os.path.isfile(file):
-		ROOT.CollectAndWriteHypoTestResults( file, args.format, args.interpretation, args.cut )
-	else:
-		print(">>> ERROR: File does not exist: %s"%file)
-		sys.exit(1)
-	print("")
-	return
+    print("")
+    if os.path.isfile(file):
+        ROOT.CollectAndWriteHypoTestResults(
+            file, args.format, args.interpretation, args.cut
+        )
+    else:
+        print(">>> ERROR: File does not exist: %s" % file)
+        sys.exit(1)
+    print("")
+    return
+
 
 def cleanUpJSON():
-	import json
-	import glob
-	for file in glob.glob("./*json"):
-		print(">>> Making file human readable: %s"%file)
-		data = json.load(open(file))
-		with open(file, 'w') as f:
-			f.write( json.dumps(data, indent=4) )
-	return
+    import json
+    import glob
+
+    for file in glob.glob("./*json"):
+        print(">>> Making file human readable: %s" % file)
+        data = json.load(open(file))
+        with open(file, "w") as f:
+            f.write(json.dumps(data, indent=4))
+    return
+
 
 def addCoordinates(fileName, coordString):
-        import json
-        import re
-        
-        coordDict = json.loads(coordString)
-        
-        jsonFileName = fileName.split('/')[-1] # grab just the filename
-        jsonFileName = jsonFileName.replace(".root","__1_harvest_list.json")
+    import json
+    import re
 
-        data = json.load(open(jsonFileName))
+    coordDict = json.loads(coordString)
+
+    jsonFileName = fileName.split("/")[-1]  # grab just the filename
+    jsonFileName = jsonFileName.replace(".root", "__1_harvest_list.json")
+
+    data = json.load(open(jsonFileName))
+
+    for i, hypo_test in enumerate(data):  # an entry is one hypo test result
+        for key in coordDict:  # each item of the result
+            # parse input arguments, thanks to Larry for regex suggestions
+            total = eval(re.sub(r"\b([a-zA-Z]+[0-9]*)\b", r'hypo_test["\g<1>"]', key))
+
+            # assign new key to value
+            hypo_test[coordDict[key]] = total
+
+    with open(jsonFileName, "w") as f:
+        f.write(json.dumps(data))
 
 
-        for i,hypo_test in enumerate(data): # an entry is one hypo test result
-                for key in coordDict: # each item of the result
-                        # parse input arguments, thanks to Larry for regex suggestions
-                        total = eval( re.sub(r'\b([a-zA-Z]+[0-9]*)\b', r'hypo_test["\g<1>"]',key))
-                                        
-                        # assign new key to value
-                        hypo_test[ coordDict[key] ] = total
-                                
-        with open(jsonFileName,"w") as f:
-                f.write( json.dumps(data) )
-        
 if __name__ == "__main__":
-	main()
+    main()

--- a/scripts/contourPlotter.py
+++ b/scripts/contourPlotter.py
@@ -1,245 +1,304 @@
 #!/usr/bin/env python
 
-# contourPlotter.py #################
+# contourPlotter.py
 #
 # Tools for making final contour plots. See contourPlotterExample.py
 #
 # By: Larry Lee - Dec 2017
 
 import ROOT
+
 ROOT.gROOT.SetBatch()
 
 from array import array
 
+
 class contourPlotter:
-	def __init__(self, plotName="test", xSize=800, ySize=600):
-		self.plotName = plotName
-		self.xSize    = xSize
-		self.ySize    = ySize
-		self.canvas   = ROOT.TCanvas(self.plotName,self.plotName,xSize,ySize)
+    def __init__(self, plotName="test", xSize=800, ySize=600):
+        self.plotName = plotName
+        self.xSize = xSize
+        self.ySize = ySize
+        self.canvas = ROOT.TCanvas(self.plotName, self.plotName, xSize, ySize)
 
-		self.canvas.SetLeftMargin(0.2)
-		self.canvas.SetRightMargin(0.07)
-		self.canvas.SetTopMargin(0.07)
+        self.canvas.SetLeftMargin(0.2)
+        self.canvas.SetRightMargin(0.07)
+        self.canvas.SetTopMargin(0.07)
 
-		self.xAxisLabel = "x label"
-		self.yAxisLabel = "y label"
+        self.xAxisLabel = "x label"
+        self.yAxisLabel = "y label"
 
-		self.processLabel = "Process Title -- Describe The Grid!"
-		self.lumiLabel = "#sqrt{s}=XX TeV, YY fb^{-1}, All limits at 95% CL"
-                self.figLabel = "#it{Example Label}"
+        self.processLabel = "Process Title -- Describe The Grid!"
+        self.lumiLabel = "#sqrt{s}=XX TeV, YY fb^{-1}, All limits at 95% CL"
+        self.figLabel = "#it{Example Label}"
 
-		self.bottomObject = 0
-		self.legendObjects = []
+        self.bottomObject = 0
+        self.legendObjects = []
 
-		return
+        return
 
+    def setXAxisLabel(self, label=""):
+        self.xAxisLabel = label
+        if self.bottomObject:
+            self.bottomObject.GetXaxis().SetTitle(self.xAxisLabel)
+        return
 
-	def setXAxisLabel(self, label=""):
-		self.xAxisLabel = label
-		if self.bottomObject:
-			self.bottomObject.GetXaxis().SetTitle(self.xAxisLabel)
-		return
+    def setYAxisLabel(self, label=""):
+        self.yAxisLabel = label
+        if self.bottomObject:
+            self.bottomObject.GetYaxis().SetTitle(self.yAxisLabel)
+        return
 
-	def setYAxisLabel(self, label=""):
-		self.yAxisLabel = label
-		if self.bottomObject:
-			self.bottomObject.GetYaxis().SetTitle(self.yAxisLabel)
-		return
+    def setYAxisLog(self, b=1):
+        if self.canvas:
+            self.canvas.SetLogy(b)
+        return
 
-	def setYAxisLog(self, b=1):
-		if self.canvas:
-			self.canvas.SetLogy(b)
-		return
+    def drawAxes(self, axisRange=[0, 0, 2000, 2000]):
+        self.canvas.cd()
+        self.bottomObject = self.canvas.DrawFrame(*axisRange)
+        self.bottomObject.SetTitle(f";{self.xAxisLabel};{self.yAxisLabel}")
+        self.bottomObject.GetYaxis().SetTitleOffset(1.8)
+        self.canvas.Update()
+        return
 
-	def drawAxes(self, axisRange=[0,0,2000,2000]):
-		self.canvas.cd()
-		self.bottomObject = self.canvas.DrawFrame( *axisRange )
-		self.bottomObject.SetTitle(";%s;%s"%(self.xAxisLabel,self.yAxisLabel) )
-		self.bottomObject.GetYaxis().SetTitleOffset(1.8)
-		self.canvas.Update()
-		return
+    def drawOneSigmaBand(
+        self, band, color=ROOT.TColor.GetColor("#ffd700"), alpha=0.5, legendOrder=0
+    ):
+        self.canvas.cd()
+        band.SetFillColorAlpha(color, alpha)
+        band.SetFillStyle(1001)
+        band.SetLineStyle(1)
+        band.SetLineWidth(1)
+        band.SetLineColorAlpha(ROOT.kGray, 0.5)
+        band.Draw("F")
+        band.Draw("L")
+        self.canvas.Update()
+        tmpLegendObject = band.Clone("1SigmaBand")
+        tmpLegendObject.SetLineColor(ROOT.kBlack)
+        tmpLegendObject.SetLineStyle(7)
+        tmpLegendObject.SetLineWidth(1)
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (
+                    legendOrder,
+                    tmpLegendObject,
+                    "Expected Limit (#pm1 #sigma_{exp})",
+                    "lf",
+                )
+            )
+        return
 
-	def drawOneSigmaBand(self, band, color=ROOT.TColor.GetColor("#ffd700"), alpha=0.5, legendOrder=0):
-		self.canvas.cd()
-		band.SetFillColorAlpha(color,alpha)
-		band.SetFillStyle(1001)
-		band.SetLineStyle(1)
-		band.SetLineWidth(1)
-		band.SetLineColorAlpha(ROOT.kGray,0.5)
-		band.Draw("F")
-		band.Draw("L")
-		self.canvas.Update()
-		tmpLegendObject = band.Clone("1SigmaBand")
-		tmpLegendObject.SetLineColor(ROOT.kBlack)
-		tmpLegendObject.SetLineStyle(7)
-		tmpLegendObject.SetLineWidth(1)
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, tmpLegendObject, "Expected Limit (#pm1 #sigma_{exp})", "lf" ) )
-		return
+    def drawExpected(
+        self,
+        curve,
+        color=ROOT.kBlack,
+        alpha=0.9,
+        legendOrder=None,
+        title="Expected Limit",
+        drawOption="L",
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(7)
+        curve.SetLineWidth(1)
+        curve.Draw(drawOption)
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append((legendOrder, curve, title, "l"))
+        return
 
-	def drawExpected(self, curve, color=ROOT.kBlack, alpha=0.9, legendOrder=None, title="Expected Limit", drawOption="L"):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(7)
-		curve.SetLineWidth(1)
-		curve.Draw(drawOption)
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve, title, "l" ) )
-		return
+    def drawObserved(
+        self,
+        curve,
+        title="Observed Limit (#pm1 #sigma_{theory}^{SUSY})",
+        color=ROOT.TColor.GetColor("#800000"),
+        alpha=0.7,
+        legendOrder=1,
+        drawOption="L",
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(1)
+        curve.SetLineWidth(3)
+        curve.Draw(drawOption)
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (legendOrder, curve.Clone("Observed"), title, "L")
+            )
+        return
 
-	def drawObserved(self, curve, title="Observed Limit (#pm1 #sigma_{theory}^{SUSY})", color=ROOT.TColor.GetColor("#800000"), alpha=0.7, legendOrder=1, drawOption="L"):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(1)
-		curve.SetLineWidth(3)
-		curve.Draw(drawOption)
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve.Clone("Observed"), title, "L" ) )
-		return
+    def drawTheoryUncertaintyCurve(
+        self, curve, color=ROOT.TColor.GetColor("#800000"), alpha=0.7, style=3
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(style)
+        curve.SetLineWidth(1)
+        curve.Draw("L")
+        self.canvas.Update()
+        return
 
-	def drawTheoryUncertaintyCurve(self, curve, color=ROOT.TColor.GetColor("#800000"), alpha=0.7,  style=3):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(style)
-		curve.SetLineWidth(1)
-		curve.Draw("L")
-		self.canvas.Update()
-		return
+    def drawTextFromTGraph2D(
+        self,
+        graph,
+        title="Grey numbers represent blah",
+        color=ROOT.TColor.GetColor("#000000"),
+        alpha=0.6,
+        angle=30,
+        size=0.015,
+        format="%.1g",
+        titlesize=0.03,
+    ):
+        self.canvas.cd()
+        tmpText = ROOT.TLatex()
+        tmpText.SetTextSize(size)
+        tmpText.SetTextColorAlpha(color, alpha)
+        tmpText.SetTextAngle(angle)
+        x, y, z, n = graph.GetX(), graph.GetY(), graph.GetZ(), graph.GetN()
+        for i in range(n):
+            tmpText.DrawLatex(x[i], y[i], format % z[i])
 
-	def drawTextFromTGraph2D(self, graph, title="Grey numbers represent blah", color=ROOT.TColor.GetColor("#000000"), alpha=0.6, angle=30, size=0.015, format="%.1g", titlesize = 0.03):
-		self.canvas.cd()
-		tmpText = ROOT.TLatex()
-		tmpText.SetTextSize(size)
-		tmpText.SetTextColorAlpha(color,alpha)
-		tmpText.SetTextAngle(angle)
-		x,y,z,n = graph.GetX(), graph.GetY(), graph.GetZ(), graph.GetN()
-		for i in range(n):
-			tmpText.DrawLatex(x[i],y[i],format%z[i])
+        tmpText.SetTextSize(titlesize)
+        tmpText.SetTextAngle(-90)
+        tmpText.DrawLatexNDC(0.94, 0.9, title)
+        self.canvas.Update()
+        return
 
-		tmpText.SetTextSize(titlesize)
-		tmpText.SetTextAngle(-90)
-		tmpText.DrawLatexNDC(0.94,0.9,title)
-		self.canvas.Update()
-		return
+    def drawShadedRegion(
+        self, curve, color=ROOT.kGray, alpha=0.5, title="title", legendOrder=2
+    ):
+        self.canvas.cd()
+        curve.SetFillStyle(1001)
+        curve.SetFillColorAlpha(color, alpha)
+        curve.SetLineStyle(1)
+        curve.SetLineWidth(1)
+        curve.SetLineColorAlpha(ROOT.kGray, 0.5)
+        curve.Draw("F")
+        curve.Draw("L")
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (legendOrder, curve.Clone("ShadedRegion_" + title), title, "F")
+            )
+        return
 
-	def drawShadedRegion(self, curve, color=ROOT.kGray, alpha=0.5, title="title", legendOrder=2):
-		self.canvas.cd()
-		curve.SetFillStyle(1001)
-		curve.SetFillColorAlpha(color,alpha)
-		curve.SetLineStyle(1)
-		curve.SetLineWidth(1)
-		curve.SetLineColorAlpha(ROOT.kGray,0.5)
-		curve.Draw("F")
-		curve.Draw("L")
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve.Clone("ShadedRegion_"+title), title, "F" ) )
-		return
+    def drawLine(
+        self, coordinates, label="", color=ROOT.kGray, style=7, labelLocation=0, angle=0
+    ):
+        self.canvas.cd()
+        tmpLine = ROOT.TLine()
+        tmpLine.SetLineColorAlpha(color, 0.9)
+        tmpLine.SetLineStyle(style)
+        tmpLine.DrawLine(*coordinates)
+        xmin, ymin, xmax, ymax = coordinates
 
-	def drawLine(self, coordinates, label = "", color = ROOT.kGray, style = 7, labelLocation=0 , angle=0):
-		self.canvas.cd()
-		tmpLine = ROOT.TLine()
-		tmpLine.SetLineColorAlpha(color,0.9)
-		tmpLine.SetLineStyle(style)
-		tmpLine.DrawLine(*coordinates)
-		xmin,ymin,xmax,ymax = coordinates
+        tmpLineLabel = ROOT.TLatex()
+        tmpLineLabel.SetTextSize(0.028)
+        tmpLineLabel.SetTextColor(color)
+        tmpLineLabel.SetTextAngle(angle)
+        if labelLocation:
+            tmpLineLabel.DrawLatex(labelLocation[0], labelLocation[1], label)
+        else:
+            tmpLineLabel.DrawLatex(
+                coordinates[0] + 0.1 * (coordinates[2] - coordinates[0]),
+                coordinates[1] + 0.12 * (coordinates[3] - coordinates[1]),
+                label,
+            )
 
-		tmpLineLabel = ROOT.TLatex()
-		tmpLineLabel.SetTextSize(0.028)
-		tmpLineLabel.SetTextColor(color)
-		tmpLineLabel.SetTextAngle(angle)
-		if labelLocation:
-			tmpLineLabel.DrawLatex(labelLocation[0],labelLocation[1],label)
-		else:
-			tmpLineLabel.DrawLatex(coordinates[0]+0.1*(coordinates[2]-coordinates[0]),
-				coordinates[1]+0.12*(coordinates[3]-coordinates[1]),
-				label)
+        self.canvas.Update()
+        return
 
-		self.canvas.Update()
-		return
+    def decorateCanvas(self):
+        self.canvas.cd()
+        latexObject = ROOT.TLatex()
+        latexObject.SetTextSize(0.028)
+        latexObject.DrawLatexNDC(0.2, 0.95, self.processLabel)
 
-	def decorateCanvas(self):
-		self.canvas.cd()
-		latexObject = ROOT.TLatex()
-		latexObject.SetTextSize(0.028)
-		latexObject.DrawLatexNDC(0.2,0.95,self.processLabel)
+        latexObject.SetTextSize(0.037)
+        latexObject.DrawLatexNDC(0.24, 0.8, self.lumiLabel)
 
-		latexObject.SetTextSize(0.037)
-		latexObject.DrawLatexNDC(0.24, 0.8, self.lumiLabel)
+        latexObject.SetTextSize(0.05)
+        latexObject.DrawLatexNDC(0.24, 0.85, self.figLabel)
 
-		latexObject.SetTextSize(0.05)
-		latexObject.DrawLatexNDC(0.24, 0.85, self.figLabel)
+        ROOT.gPad.RedrawAxis()
+        self.canvas.Update()
+        return
 
-		ROOT.gPad.RedrawAxis()
-		self.canvas.Update()
-		return
+    def createLegend(self, shape=(0.22, 0.55, 0.65, 0.75)):
+        self.canvas.cd()
+        legend = ROOT.TLegend(*shape)
+        ROOT.SetOwnership(legend, 0)
+        legend.SetBorderSize(0)
+        legend.SetFillStyle(0)
+        legend.SetTextFont(42)
 
-	def createLegend(self, shape=(0.22,0.55,0.65,0.75) ):
-		self.canvas.cd()
-		legend=ROOT.TLegend(*shape)
-		ROOT.SetOwnership( legend, 0 )
-		legend.SetBorderSize(0)
-		legend.SetFillStyle(0)
-		legend.SetTextFont(42)
+        self.legendObjects.sort(key=lambda x: x[0], reverse=False)
+        for iItem, (legendOrder, item, title, style) in enumerate(self.legendObjects):
+            legend.AddEntry(item, title, style)
 
-		self.legendObjects.sort(key=lambda x: x[0], reverse=False)
-		for iItem, (legendOrder,item,title,style) in enumerate(self.legendObjects):
-			legend.AddEntry(item,title,style)
+        return legend
 
-		return legend
+    def drawTheoryLegendLines(
+        self,
+        xyCoord,
+        length=0.05,
+        ySeparation=0.026,
+        color=ROOT.TColor.GetColor("#800000"),
+        alpha=0.7,
+        style=3,
+    ):
+        self.canvas.cd()
+        tmpLine = ROOT.TLine()
+        tmpLine.SetLineColorAlpha(color, alpha)
+        tmpLine.SetLineStyle(style)
+        tmpLine.DrawLineNDC(xyCoord[0], xyCoord[1], xyCoord[0] + length, xyCoord[1])
+        tmpLine.DrawLineNDC(
+            xyCoord[0],
+            xyCoord[1] + ySeparation,
+            xyCoord[0] + length,
+            xyCoord[1] + ySeparation,
+        )
 
+    def writePlot(self, format="pdf"):
+        self.canvas.SaveAs(f"{self.plotName:s}.{format:s}")
+        return
 
-	def drawTheoryLegendLines(self, xyCoord, length=0.05, ySeparation=0.026, color=ROOT.TColor.GetColor("#800000"), alpha=0.7, style=3 ):
-		self.canvas.cd()
-		tmpLine = ROOT.TLine()
-		tmpLine.SetLineColorAlpha(color,alpha)
-		tmpLine.SetLineStyle(style)
-		tmpLine.DrawLineNDC(xyCoord[0],xyCoord[1],xyCoord[0]+length,xyCoord[1])
-		tmpLine.DrawLineNDC(xyCoord[0],xyCoord[1]+ySeparation,xyCoord[0]+length,xyCoord[1]+ySeparation)
+    # Pass a lambda function, e.g. y_new = lambda x,y : x - y
+    def rotateTGraph(self, tg, x_new, y_new):
+        n = tg.GetN()
+        x = array("d")
+        y = array("d")
+        for i in range(n):
+            x_temp = ROOT.Double()
+            y_temp = ROOT.Double()
+            tg.GetPoint(i, x_temp, y_temp)
 
-	def writePlot(self, format="pdf"):
-		self.canvas.SaveAs(f"{self.plotName:s}.{format:s}")
-		return
+            x.append(x_new(x_temp, y_temp))
+            y.append(y_new(x_temp, y_temp))
 
-        # Pass a lambda function, e.g. y_new = lambda x,y : x - y
-        def rotateTGraph(self, tg, x_new, y_new):
+        tg_new = ROOT.TGraph(n, x, y)
 
-            n = tg.GetN()
-            x = array( 'd' )
-            y = array( 'd' )
-            for i in range(n):
-                x_temp = ROOT.Double()
-                y_temp = ROOT.Double()
-                tg.GetPoint(i, x_temp, y_temp)
-                    
-                x.append( x_new(x_temp, y_temp) )
-                y.append( y_new(x_temp, y_temp) )
+        return tg_new
 
-            tg_new = ROOT.TGraph(n, x, y)
+    def rotateTGraph2D(self, tg, x_new, y_new):
 
-            return tg_new
+        n = tg.GetN()
+        x = array("d")
+        y = array("d")
+        z = array("d")
 
-        def rotateTGraph2D(self, tg, x_new, y_new):
-            
-            n = tg.GetN()
-            x = array( 'd' )
-            y = array( 'd' )
-            z = array( 'd' )
+        # tg.GetPoint(i, x_temp, y_temp, z_temp) # this doesn't exit in old root versions
 
-            #tg.GetPoint(i, x_temp, y_temp, z_temp) # this doesn't exit in old root versions
+        x_temp = tg.GetX()
+        y_temp = tg.GetY()
+        z_temp = tg.GetZ()
 
-            x_temp = tg.GetX()
-            y_temp = tg.GetY()
-            z_temp = tg.GetZ()
-            
-            for i in range(n):
-                x.append( x_new(x_temp[i], y_temp[i]) )
-                y.append( y_new(x_temp[i], y_temp[i]) )
-                z.append( z_temp[i] )
+        for i in range(n):
+            x.append(x_new(x_temp[i], y_temp[i]))
+            y.append(y_new(x_temp[i], y_temp[i]))
+            z.append(z_temp[i])
 
-            tg_new = ROOT.TGraph2D(n, x, y, z)
+        tg_new = ROOT.TGraph2D(n, x, y, z)
 
-            return tg_new
+        return tg_new

--- a/scripts/multiplexJSON.py
+++ b/scripts/multiplexJSON.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# multiplexJSON.py #################
+# multiplexJSON.py
 #
 # A "multiplexer" to combine many JSON files (like for different SRs) and outputs
 # a single JSON with the "best" SR written out. Default figure of merit is expected CLs
@@ -11,196 +11,242 @@
 import json
 import argparse
 import glob
-import os,sys
+import os, sys
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--inputFiles','-i', type=str, nargs='+', help='input json files', required=True)
-parser.add_argument("--outputFile","-o",  type=str, help="output json" , default = "outputJSON.json")
-parser.add_argument("--figureOfMerit","-f",  type=str, help="figure of merit", default = "CLsexp")
-parser.add_argument("--modelDef","-m",  type=str, help="comma separated list of variables that define a model", default = "mg,mlsp")
-parser.add_argument("--ignoreTheory","-t",      help = "ignore theory variation files", action="store_true", default=False)
-parser.add_argument("--ignoreUL",    "-u",      help = "ignore upper limit files", action="store_true", default=False)
-parser.add_argument("--debug","-d",      help = "debug", action="store_true", default=False)
+parser.add_argument(
+    "--inputFiles", "-i", type=str, nargs="+", help="input json files", required=True
+)
+parser.add_argument(
+    "--outputFile", "-o", type=str, help="output json", default="outputJSON.json"
+)
+parser.add_argument(
+    "--figureOfMerit", "-f", type=str, help="figure of merit", default="CLsexp"
+)
+parser.add_argument(
+    "--modelDef",
+    "-m",
+    type=str,
+    help="comma separated list of variables that define a model",
+    default="mg,mlsp",
+)
+parser.add_argument(
+    "--ignoreTheory",
+    "-t",
+    help="ignore theory variation files",
+    action="store_true",
+    default=False,
+)
+parser.add_argument(
+    "--ignoreUL",
+    "-u",
+    help="ignore upper limit files",
+    action="store_true",
+    default=False,
+)
+parser.add_argument("--debug", "-d", help="debug", action="store_true", default=False)
 
 args = parser.parse_args()
 
 
 try:
-	import pandas as pd
+    import pandas as pd
 except:
-	print(">>> You need scipy/matplotlib to run this. And you had to have run harvestToContours in scipy mode [default]")
-	print(">>> In an ATLAS environment, you can...")
-	print('>>> > lsetup "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pyanalysis" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pytools" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pygraphics" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt ROOT" ')
-	print(">>> ")
-	print(">>> Try that and then run this again!")
-	sys.exit(1)
-
+    print(
+        ">>> You need scipy/matplotlib to run this. And you had to have run harvestToContours in scipy mode [default]"
+    )
+    print(">>> In an ATLAS environment, you can...")
+    print(
+        '>>> > lsetup "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pyanalysis" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pytools" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt pygraphics" "lcgenv -p LCG_93 x86_64-slc6-gcc62-opt ROOT" '
+    )
+    print(">>> ")
+    print(">>> Try that and then run this again!")
+    sys.exit(1)
 
 
 def main():
 
-	print(">>>")
-	print(">>> Welcome to multiplexJSON!")
+    print(">>>")
+    print(">>> Welcome to multiplexJSON!")
 
-	# Print out the settings
-	for setting in dir(args):
-		if not setting[0]=="_":
-			print(">>> ... Setting: {: >20}:  {}".format(setting, eval("args.%s"%setting) ))
+    # Print out the settings
+    for setting in dir(args):
+        if not setting[0] == "_":
+            print(
+                ">>> ... Setting: {: >20}:  {}".format(
+                    setting, eval("args.%s" % setting)
+                )
+            )
 
-	print(">>> ")
+    print(">>> ")
 
-	databaseList = []
+    databaseList = []
 
-	databaseListTheoryUp = []
-	databaseListTheoryDown = []
-	databaseListUpperLimit = []
+    databaseListTheoryUp = []
+    databaseListTheoryDown = []
+    databaseListUpperLimit = []
 
-	for filename in args.inputFiles:
-		if filename == args.outputFile:
-			continue
-		print(">>> Adding input file: %s"%filename)
-		with open(filename) as data_file:
-			data = json.load(data_file)
-			df = pd.DataFrame(data, columns=list(data[0].keys()))
-			df['fID'] = filename
-			databaseList.append(df)
+    for filename in args.inputFiles:
+        if filename == args.outputFile:
+            continue
+        print(">>> Adding input file: %s" % filename)
+        with open(filename) as data_file:
+            data = json.load(data_file)
+            df = pd.DataFrame(data, columns=list(data[0].keys()))
+            df["fID"] = filename
+            databaseList.append(df)
 
-			if args.debug:
-				print(">>> Loading %s"%filename)
-				print(">>> ...has %d models "%len(df))
+            if args.debug:
+                print(">>> Loading %s" % filename)
+                print(">>> ...has %d models " % len(df))
 
-		print(">>> Looking for related files")
+        print(">>> Looking for related files")
 
-		if "Nominal" in filename and not args.ignoreTheory:
+        if "Nominal" in filename and not args.ignoreTheory:
 
-			try:
-				with open(filename.replace("Nominal","Up")) as data_file:
-					print(">>> >>> Adding input file for theory up variation")
-					data = json.load(data_file)
-					df = pd.DataFrame(data, columns=list(data[0].keys()))
-					df['fID'] = filename
-					databaseListTheoryUp.append(df)
-			except:
-				print(">>> Can't find %s"%filename.replace("Nominal","Up"))
+            try:
+                with open(filename.replace("Nominal", "Up")) as data_file:
+                    print(">>> >>> Adding input file for theory up variation")
+                    data = json.load(data_file)
+                    df = pd.DataFrame(data, columns=list(data[0].keys()))
+                    df["fID"] = filename
+                    databaseListTheoryUp.append(df)
+            except:
+                print(">>> Can't find %s" % filename.replace("Nominal", "Up"))
 
-			try:
-				with open(filename.replace("Nominal","Down")) as data_file:
-					print(">>> >>> Adding input file for theory down variation")
-					data = json.load(data_file)
-					df = pd.DataFrame(data, columns=list(data[0].keys()))
-					df['fID'] = filename
-					databaseListTheoryDown.append(df)
-			except:
-				print(">>> Can't find %s"%filename.replace("Nominal","Down"))
+            try:
+                with open(filename.replace("Nominal", "Down")) as data_file:
+                    print(">>> >>> Adding input file for theory down variation")
+                    data = json.load(data_file)
+                    df = pd.DataFrame(data, columns=list(data[0].keys()))
+                    df["fID"] = filename
+                    databaseListTheoryDown.append(df)
+            except:
+                print(">>> Can't find %s" % filename.replace("Nominal", "Down"))
 
-		if "Nominal" in filename and not args.ignoreUL:
+        if "Nominal" in filename and not args.ignoreUL:
 
-			try:
-				with open(filename.replace("fixSigXSecNominal_hypotest","upperlimit")) as data_file:
-					print(">>> >>> Adding input file for upper limits")
-					data = json.load(data_file)
-					df = pd.DataFrame(data, columns=list(data[0].keys()))
-					df['fID'] = filename
-					databaseListUpperLimit.append(df)
-			except:
-				print(">>> Can't find %s"%filename.replace("Nominal","Up"))
+            try:
+                with open(
+                    filename.replace("fixSigXSecNominal_hypotest", "upperlimit")
+                ) as data_file:
+                    print(">>> >>> Adding input file for upper limits")
+                    data = json.load(data_file)
+                    df = pd.DataFrame(data, columns=list(data[0].keys()))
+                    df["fID"] = filename
+                    databaseListUpperLimit.append(df)
+            except:
+                print(">>> Can't find %s" % filename.replace("Nominal", "Up"))
 
+    database = pd.concat(databaseList, ignore_index=True)
+    if len(databaseListTheoryUp):
+        databaseTheoryUp = pd.concat(databaseListTheoryUp, ignore_index=True)
+        databaseTheoryDown = pd.concat(databaseListTheoryDown, ignore_index=True)
+    if len(databaseListUpperLimit):
+        databaseUpperLimit = pd.concat(databaseListUpperLimit, ignore_index=True)
 
-	database = pd.concat(databaseList, ignore_index=True)
-	if len(databaseListTheoryUp):
-		databaseTheoryUp   = pd.concat(databaseListTheoryUp, ignore_index=True)
-		databaseTheoryDown = pd.concat(databaseListTheoryDown, ignore_index=True)
-	if len(databaseListUpperLimit):
-		databaseUpperLimit = pd.concat(databaseListUpperLimit, ignore_index=True)
+    if args.debug:
+        print(">>> Full database has length: %d" % len(database))
 
-	if args.debug:
-		print(">>> Full database has length: %d"%len(database))
+    # cleaning up the bad stuff!
+    database = database[(database.CLsexp != 0) & database.failedstatus == 0]
 
-	# cleaning up the bad stuff!
-	database = database[(database.CLsexp != 0) & database.failedstatus==0]
+    try:
+        listOfModels = database[args.modelDef.split(",")].drop_duplicates()
+    except:
+        print(
+            ">>> Problem! The model definition variables don't seem to exist! Quitting."
+        )
+        sys.exit(1)
 
-	try:
-		listOfModels = database[args.modelDef.split(",")].drop_duplicates()
-	except:
-		print(">>> Problem! The model definition variables don't seem to exist! Quitting.")
-		sys.exit(1)
+    print(">>> Number of signal models considered: %s" % len(listOfModels))
 
-	print(">>> Number of signal models considered: %s"%len(listOfModels))
+    if args.debug:
+        print(">>> ... List of Signal Models:")
+        print(listOfModels)
 
-	if args.debug:
-		print(">>> ... List of Signal Models:")
-		print(listOfModels)
+    outputDB = doTheMuxing(database, listOfModels)
 
-	outputDB = doTheMuxing(database,listOfModels)
+    # Handle the theory variation databses using the optimization from the nominal...
 
-	# Handle the theory variation databses using the optimization from the nominal...
+    if len(databaseListTheoryUp):
+        outputDBTheoryUp = doTheMuxing(databaseTheoryUp, listOfModels, outputDB)
+        outputDBTheoryDown = doTheMuxing(databaseTheoryDown, listOfModels, outputDB)
 
-	if len(databaseListTheoryUp):
-		outputDBTheoryUp   = doTheMuxing(databaseTheoryUp,listOfModels, outputDB)
-		outputDBTheoryDown = doTheMuxing(databaseTheoryDown,listOfModels, outputDB)
+    # Handle the theory variation databses using the optimization from the nominal...
 
-	# Handle the theory variation databses using the optimization from the nominal...
+    if len(databaseListUpperLimit):
+        outputDBUpperLimit = doTheMuxing(databaseUpperLimit, listOfModels, outputDB)
 
-	if len(databaseListUpperLimit):
-		outputDBUpperLimit   = doTheMuxing(databaseUpperLimit,listOfModels, outputDB)
+    print(">>> Writing output json: %s" % args.outputFile)
 
-	print(">>> Writing output json: %s"%args.outputFile)
+    writeDBOutToFile(outputDB, args.outputFile)
 
-	writeDBOutToFile(outputDB,args.outputFile)
+    if len(databaseListTheoryUp):
+        print(">>> Writing output json for theory variations *_[Up/Down].json ")
+        writeDBOutToFile(
+            outputDB, args.outputFile.replace(".json", "") + "_Nominal.json"
+        )
+        writeDBOutToFile(
+            outputDBTheoryUp, args.outputFile.replace(".json", "") + "_Up.json"
+        )
+        writeDBOutToFile(
+            outputDBTheoryDown, args.outputFile.replace(".json", "") + "_Down.json"
+        )
 
-	if len(databaseListTheoryUp):
-		print(">>> Writing output json for theory variations *_[Up/Down].json ")
-		writeDBOutToFile(outputDB,args.outputFile.replace(".json","")+"_Nominal.json")
-		writeDBOutToFile(outputDBTheoryUp,  args.outputFile.replace(".json","")+"_Up.json")
-		writeDBOutToFile(outputDBTheoryDown,args.outputFile.replace(".json","")+"_Down.json")
+    if len(databaseListUpperLimit):
+        print(">>> Writing output json for upper limit ")
+        writeDBOutToFile(
+            outputDBUpperLimit,
+            args.outputFile.replace(".json", "") + "_UpperLimit.json",
+        )
 
-	if len(databaseListUpperLimit):
-		print(">>> Writing output json for upper limit ")
-		writeDBOutToFile(outputDBUpperLimit,args.outputFile.replace(".json","")+"_UpperLimit.json")
+    print(">>> Done!")
+    print(">>>")
 
-	print(">>> Done!")
-	print(">>>")
+    return
 
-	return
 
 def writeDBOutToFile(DB, filename):
-	tmpDict = DB.to_dict(orient = "records")
-	with open(filename, 'w') as f:
-		f.write( json.dumps(tmpDict, indent=4) )
+    tmpDict = DB.to_dict(orient="records")
+    with open(filename, "w") as f:
+        f.write(json.dumps(tmpDict, indent=4))
 
-def doTheMuxing(database,listOfModels, nominalDatabase=0):
 
-	outputDatabaseList = []
+def doTheMuxing(database, listOfModels, nominalDatabase=0):
 
-	for index, model in listOfModels.iterrows():
+    outputDatabaseList = []
 
-		tmpDatabase = database
+    for index, model in listOfModels.iterrows():
 
-		# Select for only those rows that correspond to my model point
-		for item in list(model.index):
-			tmpDatabase = tmpDatabase.loc[tmpDatabase[item] == model[item]]
+        tmpDatabase = database
 
-		# Now I've filtered out so I'm only looking at statements for this specific model!
+        # Select for only those rows that correspond to my model point
+        for item in list(model.index):
+            tmpDatabase = tmpDatabase.loc[tmpDatabase[item] == model[item]]
 
-		# Use figure of merit to do optimization
-		if type(nominalDatabase)==int:
-			bestRow = tmpDatabase.loc[[tmpDatabase[args.figureOfMerit].idxmin()]]
+        # Now I've filtered out so I'm only looking at statements for this specific model!
 
-		# Use nominalDatabase that has already been optimized for choosing best row
-		else:
+        # Use figure of merit to do optimization
+        if type(nominalDatabase) == int:
+            bestRow = tmpDatabase.loc[[tmpDatabase[args.figureOfMerit].idxmin()]]
 
-			tmpNominalDatabase = nominalDatabase
-			# Select for only those rows that correspond to my model point
-			for item in list(model.index):
-				tmpNominalDatabase = tmpNominalDatabase.loc[tmpNominalDatabase[item] == model[item]]
+        # Use nominalDatabase that has already been optimized for choosing best row
+        else:
 
-			bestRow = tmpDatabase[(tmpDatabase.fID == tmpNominalDatabase.fID.iloc[0])]
+            tmpNominalDatabase = nominalDatabase
+            # Select for only those rows that correspond to my model point
+            for item in list(model.index):
+                tmpNominalDatabase = tmpNominalDatabase.loc[
+                    tmpNominalDatabase[item] == model[item]
+                ]
 
-		outputDatabaseList.append(bestRow)
+            bestRow = tmpDatabase[(tmpDatabase.fID == tmpNominalDatabase.fID.iloc[0])]
 
-	return pd.concat(outputDatabaseList)
+        outputDatabaseList.append(bestRow)
 
+    return pd.concat(outputDatabaseList)
 
 
 if __name__ == "__main__":
-	main()
+    main()


### PR DESCRIPTION
Resolves #76 

This PR simply harmonizes on scripts on using spaces for indentation over tabs as the rest of the codebase uses spaces.

**Suggested squash and merge commit message**:
```
* Harmonize scripts on using spaces over tabs to be the same as the rest of the codebase
* Update pre-commit hooks
```