### PR TITLE
fix: Parse `GenerateJSONOutput.py` input args properly

### DIFF
--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -60,13 +60,8 @@ args = parser.parse_args()
 # Print out the settings
 for arg in vars(args):
     user_input = getattr(args, arg)
-    if isinstance(user_input, list):
-        for input in user_input:
-            print(f">>> ... Setting: {arg: >20} {input: >40}")
-    else:
-        print(f">>> ... Setting: {arg: >20} {user_input: >40}")
+    print(f">>> ... Setting: {arg: >20} {str(user_input): >40}")
 print("")
-
 
 def main():
 

--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -50,16 +50,33 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+for arg in vars(args):
+    user_input = getattr(args, arg)
+    if isinstance(user_input, list):
+        for input in user_input:
+            print(f">>> ... Setting: {arg: >20} {input: >40}")
+    else:
+        print(f">>> ... Setting: {arg: >20} {user_input: >40}")
 
 # Print out the settings
-for setting in dir(args):
-    if not setting[0] == "_":
-        print(
-            ">>> ... Setting: {: >20} {: >40}".format(
-                setting, eval("args.%s" % setting)
-            )
-        )
+# for setting in dir(args):
+#     if not setting[0] == "_":
+#         # print(
+#         #     f">>> ... Setting: {setting: >20} {: >40}".format(
+#         #         setting, eval("args.%s" % setting)
+#         #     )
+#         # )
+#         print()
+#         print(setting)
+#         print(setting[0])
+#         print(args)
+#         print(
+#             f">>> ... Setting: {setting: >20} {eval(f'args.{setting}'): >40}"
+#         )
 print("")
+
+import sys
+sys.exit()
 
 import os
 import ROOT

--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -7,7 +7,14 @@
 # By: Larry Lee - Dec 2017
 
 
-import argparse, sys, os
+import argparse
+import sys
+import os
+import ROOT
+
+ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
+
+ROOT.gROOT.SetBatch()
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -59,16 +66,6 @@ for arg in vars(args):
     else:
         print(f">>> ... Setting: {arg: >20} {user_input: >40}")
 print("")
-
-import sys
-sys.exit()
-
-import os
-import ROOT
-
-ROOT.gSystem.Load(f"{os.getenv('HISTFITTER')}/lib/libSusyFitter.so")
-
-ROOT.gROOT.SetBatch()
 
 
 def main():

--- a/scripts/GenerateJSONOutput.py
+++ b/scripts/GenerateJSONOutput.py
@@ -50,6 +50,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+# Print out the settings
 for arg in vars(args):
     user_input = getattr(args, arg)
     if isinstance(user_input, list):
@@ -57,22 +58,6 @@ for arg in vars(args):
             print(f">>> ... Setting: {arg: >20} {input: >40}")
     else:
         print(f">>> ... Setting: {arg: >20} {user_input: >40}")
-
-# Print out the settings
-# for setting in dir(args):
-#     if not setting[0] == "_":
-#         # print(
-#         #     f">>> ... Setting: {setting: >20} {: >40}".format(
-#         #         setting, eval("args.%s" % setting)
-#         #     )
-#         # )
-#         print()
-#         print(setting)
-#         print(setting[0])
-#         print(args)
-#         print(
-#             f">>> ... Setting: {setting: >20} {eval(f'args.{setting}'): >40}"
-#         )
 print("")
 
 import sys


### PR DESCRIPTION
Resolves #83 


**Suggested squash and merge commit message**:
```
* Properly parse argparse arguments with `vars` and `getattr`
* Simplify imports and environmental manipulation and move to top of file
```