### PR TITLE
doc: Explicitly mention that harvestToContour uses 1-sided z-scores

### DIFF
--- a/scripts/harvestToContours.py
+++ b/scripts/harvestToContours.py
@@ -35,7 +35,7 @@ parser.add_argument("--outputFile","-o", type = str, help="output ROOT file", de
 parser.add_argument("--interpolation",   type = str, help="interpolation function for scipy (RBF): linear, cubic, gaussian, multiquadric or (griddata): nearest, linear, cubic", default = "multiquadric")
 parser.add_argument("--interpolationScheme",   type = str, help="type of interpolation for scipy: rbf, griddata", default = "rbf")
 parser.add_argument("--interpolationEpsilon", type=float, help="scipy (RBF) epsilon parameter", default = 0)
-parser.add_argument("--level",           type = float, help="contour level output. Default to 95%% CL", default = 1.64485362695)
+parser.add_argument("--level",           type = float, help="contour level output. Default to 95% CL. Note: 1-sided.", default = 1.64485362695)
 parser.add_argument("--useROOT","-r",    help = "use the root interpolation engine instead of mpl", action="store_true", default=False)
 parser.add_argument("--debug","-d",      help = "print extra debugging info", action="store_true", default=False)
 parser.add_argument("--sigmax",          type = float, help="maximum significance in sigmas", default = 5.0)


### PR DESCRIPTION
Came up in internal email and made sure to clarify.

```
* level option in harvestToContours takes a 1-sided interval, rather than 2-sided
  * nb: "survival function" in scipy terms
```
