### PR TITLE
Fix ABCD tutorial and corr plot labelling

### DIFF
--- a/analysis/tutorial/MyABCDExample.py
+++ b/analysis/tutorial/MyABCDExample.py
@@ -116,25 +116,25 @@ ana.addSamples([dataSample,backgroundSample])
 bkgSampleA = Sample("dummy_BkgA",kBlue)
 bkgSampleA.buildHisto([1],"A","cuts",0.5)
 #mu_A become the estimated Bkg events in SR
-bkgSampleA.addNormFactor("mu_A",1.0, 100,0,False)
+bkgSampleA.addNormFactor("mu_A",1.0,0,100,False)
 
 bkgSampleB = Sample("dummy_BkgB",kBlue)
 bkgSampleB.buildHisto([1],"B","cuts",0.5)
-bkgSampleB.addNormFactor("mu_A",1.0, 100,0,False)
-bkgSampleB.addNormFactor("eff_B",EffB,2.*EffB,0,False)
+bkgSampleB.addNormFactor("mu_A",1.0,0,100,False)
+bkgSampleB.addNormFactor("eff_B",EffB,0,2.*EffB,False)
 
 bkgSampleC = Sample("dummy_BkgC",kBlue)
 bkgSampleC.buildHisto([1],"C","cuts",0.5)
-bkgSampleC.addNormFactor("mu_A",1.0, 100,0,False)
-bkgSampleC.addNormFactor("eff_C",EffC,2.*EffC,0,False) 
+bkgSampleC.addNormFactor("mu_A",1.0,0,100,False)
+bkgSampleC.addNormFactor("eff_C",EffC,0,2.*EffC,False) 
 
 
 #in region D eff_B* eff_C become the eff_D, because we assume we can use ABCD method
 bkgSampleD = Sample("dummy_BkgD",kBlue)
 bkgSampleD.buildHisto([1],"D","cuts",0.5)
-bkgSampleD.addNormFactor("mu_A",1.0, 100,0,False)
-bkgSampleD.addNormFactor("eff_B",EffB,2.*EffB,0,False)
-bkgSampleD.addNormFactor("eff_C",EffC,2.*EffC,0,False)
+bkgSampleD.addNormFactor("mu_A",1.0,0,100,False)
+bkgSampleD.addNormFactor("eff_B",EffB,0,2.*EffB,False)
+bkgSampleD.addNormFactor("eff_C",EffC,0,2.*EffC,False)
 
 
 # Add the channel

--- a/scripts/contourPlotter.py
+++ b/scripts/contourPlotter.py
@@ -1,242 +1,304 @@
 #!/usr/bin/env python
 
-# contourPlotter.py #################
+# contourPlotter.py
 #
 # Tools for making final contour plots. See contourPlotterExample.py
 #
 # By: Larry Lee - Dec 2017
 
 import ROOT
+
 ROOT.gROOT.SetBatch()
 
 from array import array
 
+
 class contourPlotter:
-	def __init__(self, plotName="test", xSize=800, ySize=600):
-		self.plotName = plotName
-		self.xSize    = xSize
-		self.ySize    = ySize
-		self.canvas   = ROOT.TCanvas(self.plotName,self.plotName,xSize,ySize)
+    def __init__(self, plotName="test", xSize=800, ySize=600):
+        self.plotName = plotName
+        self.xSize = xSize
+        self.ySize = ySize
+        self.canvas = ROOT.TCanvas(self.plotName, self.plotName, xSize, ySize)
 
-		self.canvas.SetLeftMargin(0.2)
-		self.canvas.SetRightMargin(0.07)
-		self.canvas.SetTopMargin(0.07)
+        self.canvas.SetLeftMargin(0.2)
+        self.canvas.SetRightMargin(0.07)
+        self.canvas.SetTopMargin(0.07)
 
-		self.xAxisLabel = "x label"
-		self.yAxisLabel = "y label"
+        self.xAxisLabel = "x label"
+        self.yAxisLabel = "y label"
 
-		self.processLabel = "Process Title -- Describe The Grid!"
-		self.lumiLabel = "#sqrt{s}=XX TeV, YY fb^{-1}, All limits at 95% CL"
-                self.figLabel = "#it{Example Label}"
+        self.processLabel = "Process Title -- Describe The Grid!"
+        self.lumiLabel = "#sqrt{s}=XX TeV, YY fb^{-1}, All limits at 95% CL"
+        self.figLabel = "#it{Example Label}"
 
-		self.bottomObject = 0
-		self.legendObjects = []
+        self.bottomObject = 0
+        self.legendObjects = []
 
-		return
+        return
 
+    def setXAxisLabel(self, label=""):
+        self.xAxisLabel = label
+        if self.bottomObject:
+            self.bottomObject.GetXaxis().SetTitle(self.xAxisLabel)
+        return
 
-	def setXAxisLabel(self, label=""):
-		self.xAxisLabel = label
-		if self.bottomObject:
-			self.bottomObject.GetXaxis().SetTitle(self.xAxisLabel)
-		return
+    def setYAxisLabel(self, label=""):
+        self.yAxisLabel = label
+        if self.bottomObject:
+            self.bottomObject.GetYaxis().SetTitle(self.yAxisLabel)
+        return
 
-	def setYAxisLabel(self, label=""):
-		self.yAxisLabel = label
-		if self.bottomObject:
-			self.bottomObject.GetYaxis().SetTitle(self.yAxisLabel)
-		return
+    def setYAxisLog(self, b=1):
+        if self.canvas:
+            self.canvas.SetLogy(b)
+        return
 
-	def setYAxisLog(self, b=1):
-		if self.canvas:
-			self.canvas.SetLogy(b)
-		return
+    def drawAxes(self, axisRange=[0, 0, 2000, 2000]):
+        self.canvas.cd()
+        self.bottomObject = self.canvas.DrawFrame(*axisRange)
+        self.bottomObject.SetTitle(f";{self.xAxisLabel};{self.yAxisLabel}")
+        self.bottomObject.GetYaxis().SetTitleOffset(1.8)
+        self.canvas.Update()
+        return
 
-	def drawAxes(self, axisRange=[0,0,2000,2000]):
-		self.canvas.cd()
-		self.bottomObject = self.canvas.DrawFrame( *axisRange )
-		self.bottomObject.SetTitle(";%s;%s"%(self.xAxisLabel,self.yAxisLabel) )
-		self.bottomObject.GetYaxis().SetTitleOffset(1.8)
-		self.canvas.Update()
-		return
+    def drawOneSigmaBand(
+        self, band, color=ROOT.TColor.GetColor("#ffd700"), alpha=0.5, legendOrder=0
+    ):
+        self.canvas.cd()
+        band.SetFillColorAlpha(color, alpha)
+        band.SetFillStyle(1001)
+        band.SetLineStyle(1)
+        band.SetLineWidth(1)
+        band.SetLineColorAlpha(ROOT.kGray, 0.5)
+        band.Draw("F")
+        band.Draw("L")
+        self.canvas.Update()
+        tmpLegendObject = band.Clone("1SigmaBand")
+        tmpLegendObject.SetLineColor(ROOT.kBlack)
+        tmpLegendObject.SetLineStyle(7)
+        tmpLegendObject.SetLineWidth(1)
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (
+                    legendOrder,
+                    tmpLegendObject,
+                    "Expected Limit (#pm1 #sigma_{exp})",
+                    "lf",
+                )
+            )
+        return
 
-	def drawOneSigmaBand(self, band, color=ROOT.TColor.GetColor("#ffd700"), alpha=0.5, legendOrder=0):
-		self.canvas.cd()
-		band.SetFillColorAlpha(color,alpha)
-		band.SetFillStyle(1001)
-		band.SetLineStyle(1)
-		band.SetLineWidth(1)
-		band.SetLineColorAlpha(ROOT.kGray,0.5)
-		band.Draw("F")
-		band.Draw("L")
-		self.canvas.Update()
-		tmpLegendObject = band.Clone("1SigmaBand")
-		tmpLegendObject.SetLineColor(ROOT.kBlack)
-		tmpLegendObject.SetLineStyle(7)
-		tmpLegendObject.SetLineWidth(1)
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, tmpLegendObject, "Expected Limit (#pm1 #sigma_{exp})", "lf" ) )
-		return
+    def drawExpected(
+        self,
+        curve,
+        color=ROOT.kBlack,
+        alpha=0.9,
+        legendOrder=None,
+        title="Expected Limit",
+        drawOption="L",
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(7)
+        curve.SetLineWidth(1)
+        curve.Draw(drawOption)
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append((legendOrder, curve, title, "l"))
+        return
 
-	def drawExpected(self, curve, color=ROOT.kBlack, alpha=0.9, legendOrder=None, title="Expected Limit", drawOption="L"):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(7)
-		curve.SetLineWidth(1)
-		curve.Draw(drawOption)
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve, title, "l" ) )
-		return
+    def drawObserved(
+        self,
+        curve,
+        title="Observed Limit (#pm1 #sigma_{theory}^{SUSY})",
+        color=ROOT.TColor.GetColor("#800000"),
+        alpha=0.7,
+        legendOrder=1,
+        drawOption="L",
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(1)
+        curve.SetLineWidth(3)
+        curve.Draw(drawOption)
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (legendOrder, curve.Clone("Observed"), title, "L")
+            )
+        return
 
-	def drawObserved(self, curve, title="Observed Limit (#pm1 #sigma_{theory}^{SUSY})", color=ROOT.TColor.GetColor("#800000"), alpha=0.7, legendOrder=1, drawOption="L"):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(1)
-		curve.SetLineWidth(3)
-		curve.Draw(drawOption)
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve.Clone("Observed"), title, "L" ) )
-		return
+    def drawTheoryUncertaintyCurve(
+        self, curve, color=ROOT.TColor.GetColor("#800000"), alpha=0.7, style=3
+    ):
+        self.canvas.cd()
+        curve.SetLineColorAlpha(color, alpha)
+        curve.SetLineStyle(style)
+        curve.SetLineWidth(1)
+        curve.Draw("L")
+        self.canvas.Update()
+        return
 
-	def drawTheoryUncertaintyCurve(self, curve, color=ROOT.TColor.GetColor("#800000"), alpha=0.7,  style=3):
-		self.canvas.cd()
-		curve.SetLineColorAlpha(color,alpha)
-		curve.SetLineStyle(style)
-		curve.SetLineWidth(1)
-		curve.Draw("L")
-		self.canvas.Update()
-		return
+    def drawTextFromTGraph2D(
+        self,
+        graph,
+        title="Grey numbers represent blah",
+        color=ROOT.TColor.GetColor("#000000"),
+        alpha=0.6,
+        angle=30,
+        size=0.015,
+        format="%.1g",
+        titlesize=0.03,
+    ):
+        self.canvas.cd()
+        tmpText = ROOT.TLatex()
+        tmpText.SetTextSize(size)
+        tmpText.SetTextColorAlpha(color, alpha)
+        tmpText.SetTextAngle(angle)
+        x, y, z, n = graph.GetX(), graph.GetY(), graph.GetZ(), graph.GetN()
+        for i in range(n):
+            tmpText.DrawLatex(x[i], y[i], format % z[i])
 
-	def drawTextFromTGraph2D(self, graph, title="Grey numbers represent blah", color=ROOT.TColor.GetColor("#000000"), alpha=0.6, angle=30, size=0.015, format="%.1g", titlesize = 0.03):
-		self.canvas.cd()
-		tmpText = ROOT.TLatex()
-		tmpText.SetTextSize(size)
-		tmpText.SetTextColorAlpha(color,alpha)
-		tmpText.SetTextAngle(angle)
-		x,y,z,n = graph.GetX(), graph.GetY(), graph.GetZ(), graph.GetN()
-		for i in range(n):
-			tmpText.DrawLatex(x[i],y[i],format%z[i])
+        tmpText.SetTextSize(titlesize)
+        tmpText.SetTextAngle(-90)
+        tmpText.DrawLatexNDC(0.94, 0.9, title)
+        self.canvas.Update()
+        return
 
-		tmpText.SetTextSize(titlesize)
-		tmpText.SetTextAngle(-90)
-		tmpText.DrawLatexNDC(0.94,0.9,title)
-		self.canvas.Update()
-		return
+    def drawShadedRegion(
+        self, curve, color=ROOT.kGray, alpha=0.5, title="title", legendOrder=2
+    ):
+        self.canvas.cd()
+        curve.SetFillStyle(1001)
+        curve.SetFillColorAlpha(color, alpha)
+        curve.SetLineStyle(1)
+        curve.SetLineWidth(1)
+        curve.SetLineColorAlpha(ROOT.kGray, 0.5)
+        curve.Draw("F")
+        curve.Draw("L")
+        self.canvas.Update()
+        if type(legendOrder) == int:
+            self.legendObjects.append(
+                (legendOrder, curve.Clone("ShadedRegion_" + title), title, "F")
+            )
+        return
 
-	def drawShadedRegion(self, curve, color=ROOT.kGray, alpha=0.5, title="title", legendOrder=2):
-		self.canvas.cd()
-		curve.SetFillStyle(1001)
-		curve.SetFillColorAlpha(color,alpha)
-		curve.SetLineStyle(1)
-		curve.SetLineWidth(1)
-		curve.SetLineColorAlpha(ROOT.kGray,0.5)
-		curve.Draw("F")
-		curve.Draw("L")
-		self.canvas.Update()
-		if type(legendOrder) == int:
-			self.legendObjects.append( ( legendOrder, curve.Clone("ShadedRegion_"+title), title, "F" ) )
-		return
+    def drawLine(
+        self, coordinates, label="", color=ROOT.kGray, style=7, labelLocation=0, angle=0
+    ):
+        self.canvas.cd()
+        tmpLine = ROOT.TLine()
+        tmpLine.SetLineColorAlpha(color, 0.9)
+        tmpLine.SetLineStyle(style)
+        tmpLine.DrawLine(*coordinates)
+        xmin, ymin, xmax, ymax = coordinates
 
-	def drawLine(self, coordinates, label = "", color = ROOT.kGray, style = 7, labelLocation=0 , angle=0):
-		self.canvas.cd()
-		tmpLine = ROOT.TLine()
-		tmpLine.SetLineColorAlpha(color,0.9)
-		tmpLine.SetLineStyle(style)
-		tmpLine.DrawLine(*coordinates)
-		xmin,ymin,xmax,ymax = coordinates
+        tmpLineLabel = ROOT.TLatex()
+        tmpLineLabel.SetTextSize(0.028)
+        tmpLineLabel.SetTextColor(color)
+        tmpLineLabel.SetTextAngle(angle)
+        if labelLocation:
+            tmpLineLabel.DrawLatex(labelLocation[0], labelLocation[1], label)
+        else:
+            tmpLineLabel.DrawLatex(
+                coordinates[0] + 0.1 * (coordinates[2] - coordinates[0]),
+                coordinates[1] + 0.12 * (coordinates[3] - coordinates[1]),
+                label,
+            )
 
-		tmpLineLabel = ROOT.TLatex()
-		tmpLineLabel.SetTextSize(0.028)
-		tmpLineLabel.SetTextColor(color)
-		tmpLineLabel.SetTextAngle(angle)
-		if labelLocation:
-			tmpLineLabel.DrawLatex(labelLocation[0],labelLocation[1],label)
-		else:
-			tmpLineLabel.DrawLatex(coordinates[0]+0.1*(coordinates[2]-coordinates[0]),
-				coordinates[1]+0.12*(coordinates[3]-coordinates[1]),
-				label)
+        self.canvas.Update()
+        return
 
-		self.canvas.Update()
-		return
+    def decorateCanvas(self):
+        self.canvas.cd()
+        latexObject = ROOT.TLatex()
+        latexObject.SetTextSize(0.028)
+        latexObject.DrawLatexNDC(0.2, 0.95, self.processLabel)
 
-	def decorateCanvas(self):
-		self.canvas.cd()
-		latexObject = ROOT.TLatex()
-		latexObject.SetTextSize(0.028)
-		latexObject.DrawLatexNDC(0.2,0.95,self.processLabel)
+        latexObject.SetTextSize(0.037)
+        latexObject.DrawLatexNDC(0.24, 0.8, self.lumiLabel)
 
-		latexObject.SetTextSize(0.037)
-		latexObject.DrawLatexNDC(0.24, 0.8, self.lumiLabel)
+        latexObject.SetTextSize(0.05)
+        latexObject.DrawLatexNDC(0.24, 0.85, self.figLabel)
 
-		latexObject.SetTextSize(0.05)
-		latexObject.DrawLatexNDC(0.24, 0.85, self.figLabel)
+        ROOT.gPad.RedrawAxis()
+        self.canvas.Update()
+        return
 
-		ROOT.gPad.RedrawAxis()
-		self.canvas.Update()
-		return
+    def createLegend(self, shape=(0.22, 0.55, 0.65, 0.75)):
+        self.canvas.cd()
+        legend = ROOT.TLegend(*shape)
+        ROOT.SetOwnership(legend, 0)
+        legend.SetBorderSize(0)
+        legend.SetFillStyle(0)
+        legend.SetTextFont(42)
 
-	def createLegend(self, shape=(0.22,0.55,0.65,0.75) ):
-		self.canvas.cd()
-		legend=ROOT.TLegend(*shape)
-		ROOT.SetOwnership( legend, 0 )
-		legend.SetBorderSize(0)
-		legend.SetFillStyle(0)
-		legend.SetTextFont(42)
+        self.legendObjects.sort(key=lambda x: x[0], reverse=False)
+        for iItem, (legendOrder, item, title, style) in enumerate(self.legendObjects):
+            legend.AddEntry(item, title, style)
 
-		self.legendObjects.sort(key=lambda x: x[0], reverse=False)
-		for iItem, (legendOrder,item,title,style) in enumerate(self.legendObjects):
-			legend.AddEntry(item,title,style)
+        return legend
 
-		return legend
+    def drawTheoryLegendLines(
+        self,
+        xyCoord,
+        length=0.05,
+        ySeparation=0.026,
+        color=ROOT.TColor.GetColor("#800000"),
+        alpha=0.7,
+        style=3,
+    ):
+        self.canvas.cd()
+        tmpLine = ROOT.TLine()
+        tmpLine.SetLineColorAlpha(color, alpha)
+        tmpLine.SetLineStyle(style)
+        tmpLine.DrawLineNDC(xyCoord[0], xyCoord[1], xyCoord[0] + length, xyCoord[1])
+        tmpLine.DrawLineNDC(
+            xyCoord[0],
+            xyCoord[1] + ySeparation,
+            xyCoord[0] + length,
+            xyCoord[1] + ySeparation,
+        )
 
+    def writePlot(self, format="pdf"):
+        self.canvas.SaveAs(f"{self.plotName:s}.{format:s}")
+        return
 
-	def drawTheoryLegendLines(self, xyCoord, length=0.05, ySeparation=0.026, color=ROOT.TColor.GetColor("#800000"), alpha=0.7, style=3 ):
-		self.canvas.cd()
-		tmpLine = ROOT.TLine()
-		tmpLine.SetLineColorAlpha(color,alpha)
-		tmpLine.SetLineStyle(style)
-		tmpLine.DrawLineNDC(xyCoord[0],xyCoord[1],xyCoord[0]+length,xyCoord[1])
-		tmpLine.DrawLineNDC(xyCoord[0],xyCoord[1]+ySeparation,xyCoord[0]+length,xyCoord[1]+ySeparation)
+    # Pass a lambda function, e.g. y_new = lambda x,y : x - y
+    def rotateTGraph(self, tg, x_new, y_new):
+        n = tg.GetN()
+        x = array("d")
+        y = array("d")
+        for i in range(n):
+            x_temp = ROOT.Double()
+            y_temp = ROOT.Double()
+            tg.GetPoint(i, x_temp, y_temp)
 
-	def writePlot(self, format="pdf"):
-		self.canvas.SaveAs(f"{self.plotName:s}.{format:s}")
-		return
+            x.append(x_new(x_temp, y_temp))
+            y.append(y_new(x_temp, y_temp))
 
-        # Pass a lambda function, e.g. y_new = lambda x,y : x - y
-        def rotateTGraph(self, tg, x_new, y_new):
+        tg_new = ROOT.TGraph(n, x, y)
 
-            n = tg.GetN()
-            x = array( 'd' )
-            y = array( 'd' )
-            for i in range(n):
-                x_temp = tg.GetPointX(i)
-                y_temp = tg.GetPointY(i)
-                    
-                x.append( x_new(x_temp, y_temp) )
-                y.append( y_new(x_temp, y_temp) )
+        return tg_new
 
-            tg_new = ROOT.TGraph(n, x, y)
+    def rotateTGraph2D(self, tg, x_new, y_new):
 
-            return tg_new
+        n = tg.GetN()
+        x = array("d")
+        y = array("d")
+        z = array("d")
 
-        def rotateTGraph2D(self, tg, x_new, y_new):
-            
-            n = tg.GetN()
-            x = array( 'd' )
-            y = array( 'd' )
-            z = array( 'd' )
+        # tg.GetPoint(i, x_temp, y_temp, z_temp) # this doesn't exit in old root versions
 
-            x_temp = tg.GetX()
-            y_temp = tg.GetY()
-            z_temp = tg.GetZ()
-            
-            for i in range(n):
-                x.append( x_new(x_temp[i], y_temp[i]) )
-                y.append( y_new(x_temp[i], y_temp[i]) )
-                z.append( z_temp[i] )
+        x_temp = tg.GetX()
+        y_temp = tg.GetY()
+        z_temp = tg.GetZ()
 
-            tg_new = ROOT.TGraph2D(n, x, y, z)
+        for i in range(n):
+            x.append(x_new(x_temp[i], y_temp[i]))
+            y.append(y_new(x_temp[i], y_temp[i]))
+            z.append(z_temp[i])
 
-            return tg_new
+        tg_new = ROOT.TGraph2D(n, x, y, z)
+
+        return tg_new

--- a/scripts/contourPlotter.py
+++ b/scripts/contourPlotter.py
@@ -211,9 +211,8 @@ class contourPlotter:
             x = array( 'd' )
             y = array( 'd' )
             for i in range(n):
-                x_temp = ROOT.Double()
-                y_temp = ROOT.Double()
-                tg.GetPoint(i, x_temp, y_temp)
+                x_temp = tg.GetPointX(i)
+                y_temp = tg.GetPointY(i)
                     
                 x.append( x_new(x_temp, y_temp) )
                 y.append( y_new(x_temp, y_temp) )
@@ -228,8 +227,6 @@ class contourPlotter:
             x = array( 'd' )
             y = array( 'd' )
             z = array( 'd' )
-
-            #tg.GetPoint(i, x_temp, y_temp, z_temp) # this doesn't exit in old root versions
 
             x_temp = tg.GetX()
             y_temp = tg.GetY()

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -1560,29 +1560,29 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
             h_corr_reduced->Fill(index_x,index_y,h_corr->GetBinContent(ix,iy));
             index_y++;
             TString labelY = h_corr->GetYaxis()->GetBinLabel(iy);
-                  if(labelY.Contains("Lumi") || labelY.Contains("mcstat") || labelY.Contains("gamma_stat")){
-                  labelY.ReplaceAll("gamma_shape_mcstat","#gamma");
-                  labelY.ReplaceAll("gamma_stat","#gamma");
-                  labelY.ReplaceAll("_cuts_bin_0","");}
-                  if(labelY.Contains("mu")){
-                  labelY.ReplaceAll("mu","#mu");}
-                  if(labelY.Contains("alpha")){
-                  labelY.ReplaceAll("alpha","#alpha");}
+            if(labelY.Contains("Lumi") || labelY.Contains("mcstat") || labelY.Contains("gamma_stat")){
+                labelY.ReplaceAll("gamma_shape_mcstat","#gamma");
+                labelY.ReplaceAll("gamma_stat","#gamma");
+                labelY.ReplaceAll("_cuts_bin_0","");}
+            if(labelY.Contains("mu")){
+                labelY.ReplaceAll("mu","#mu");}
+            if(labelY.Contains("alpha")){
+                labelY.ReplaceAll("alpha","#alpha");}
             if (index_x==0) h_corr_reduced->GetYaxis()->SetBinLabel(index_y,labelY);
             fillHistX=true;
           }
         }
         if (fillHistX) {
           index_x++;
-           TString labelX = h_corr->GetXaxis()->GetBinLabel(ix);
-                  if(labelX.Contains("Lumi") || labelX.Contains("mcstat") || labelX.Contains("gamma_stat")){
-                  labelX.ReplaceAll("gamma_shape_mcstat","#gamma");
-                  labelX.ReplaceAll("gamma_stat","#gamma");
-                  labelX.ReplaceAll("_cuts_bin_0","");}
-                  if(labelX.Contains("mu")){
-                  labelX.ReplaceAll("mu","#mu");}
-                  if(labelX.Contains("alpha")){
-                  labelX.ReplaceAll("alpha","#alpha");}
+          TString labelX = h_corr->GetXaxis()->GetBinLabel(ix);
+          if(labelX.Contains("Lumi") || labelX.Contains("mcstat") || labelX.Contains("gamma_stat")){
+              labelX.ReplaceAll("gamma_shape_mcstat","#gamma");
+              labelX.ReplaceAll("gamma_stat","#gamma");
+              labelX.ReplaceAll("_cuts_bin_0","");}
+          if(labelX.Contains("mu")){
+              labelX.ReplaceAll("mu","#mu");}
+          if(labelX.Contains("alpha")){
+              labelX.ReplaceAll("alpha","#alpha");}
           h_corr_reduced->GetXaxis()->SetBinLabel(index_x,labelX);
         }
       }

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -1519,12 +1519,38 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
     else     gStyle->SetMarkerSize(0.25);
 
     TH2D* h_corr = (TH2D*) rFit->correlationHist(Form("h_corr_%s",rFit->GetName())); 
+    int nbins = h_corr->GetNbinsX();
+
+    for (int xbin=1; xbin<nbins+1; xbin++) {
+        TString labelX = h_corr->GetXaxis()->GetBinLabel(xbin);
+        if(labelX.Contains("Lumi") || labelX.Contains("mcstat") || labelX.Contains("gamma_stat")){
+            labelX.ReplaceAll("gamma_shape_mcstat","#gamma");
+            labelX.ReplaceAll("gamma_stat","#gamma");
+            labelX.ReplaceAll("_cuts_bin_0","");}
+        if(labelX.Contains("mu")){
+            labelX.ReplaceAll("mu","#mu");}
+        if(labelX.Contains("alpha")){
+            labelX.ReplaceAll("alpha","#alpha");}
+        h_corr->GetXaxis()->SetBinLabel(xbin,labelX);
+    }
+
+    for (int ybin=1; ybin<nbins+1; ybin++) {
+        TString labelY = h_corr->GetYaxis()->GetBinLabel(ybin);
+         if(labelY.Contains("Lumi") || labelY.Contains("mcstat") || labelY.Contains("gamma_stat")){
+            labelY.ReplaceAll("gamma_shape_mcstat","#gamma");
+            labelY.ReplaceAll("gamma_stat","#gamma");
+            labelY.ReplaceAll("_cuts_bin_0","");}
+         if(labelY.Contains("mu")){
+            labelY.ReplaceAll("mu","#mu");}
+         if(labelY.Contains("alpha")){
+            labelY.ReplaceAll("alpha","#alpha");}
+        h_corr->GetYaxis()->SetBinLabel(ybin,labelY);
+    }
 
     if (ReduceMatrix) {
       // Cleanup corrMattrix from rows and columns with content less then corrThres
       vector <int> rm_idx; rm_idx.clear();
       double corrThresh[3] = {0.01,0.1,0.2}; 
-      int nbins = h_corr->GetNbinsX();
       int index_x=0, index_y=0, Thresh1Counter;//, Thresh0Counter, Thresh2Counter;
       bool fillHistY, fillHistX;
 
@@ -1559,31 +1585,13 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
           if (fillHistY) {
             h_corr_reduced->Fill(index_x,index_y,h_corr->GetBinContent(ix,iy));
             index_y++;
-            TString labelY = h_corr->GetYaxis()->GetBinLabel(iy);
-            if(labelY.Contains("Lumi") || labelY.Contains("mcstat") || labelY.Contains("gamma_stat")){
-                labelY.ReplaceAll("gamma_shape_mcstat","#gamma");
-                labelY.ReplaceAll("gamma_stat","#gamma");
-                labelY.ReplaceAll("_cuts_bin_0","");}
-            if(labelY.Contains("mu")){
-                labelY.ReplaceAll("mu","#mu");}
-            if(labelY.Contains("alpha")){
-                labelY.ReplaceAll("alpha","#alpha");}
-            if (index_x==0) h_corr_reduced->GetYaxis()->SetBinLabel(index_y,labelY);
+            if (index_x==0) h_corr_reduced->GetYaxis()->SetBinLabel(index_y,h_corr->GetYaxis()->GetBinLabel(iy));
             fillHistX=true;
           }
         }
         if (fillHistX) {
           index_x++;
-          TString labelX = h_corr->GetXaxis()->GetBinLabel(ix);
-          if(labelX.Contains("Lumi") || labelX.Contains("mcstat") || labelX.Contains("gamma_stat")){
-              labelX.ReplaceAll("gamma_shape_mcstat","#gamma");
-              labelX.ReplaceAll("gamma_stat","#gamma");
-              labelX.ReplaceAll("_cuts_bin_0","");}
-          if(labelX.Contains("mu")){
-              labelX.ReplaceAll("mu","#mu");}
-          if(labelX.Contains("alpha")){
-              labelX.ReplaceAll("alpha","#alpha");}
-          h_corr_reduced->GetXaxis()->SetBinLabel(index_x,labelX);
+          h_corr_reduced->GetXaxis()->SetBinLabel(index_x,h_corr->GetXaxis()->GetBinLabel(ix));
         }
       }
 

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -1599,12 +1599,6 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
     c_corr->SaveAs("results/"+anaName+"/"+canName+".pdf");
     c_corr->SaveAs("results/"+anaName+"/"+canName+".eps");
 
-    gStyle->SetMarkerSize(orig_MarkerSize);
-    gStyle->SetMarkerColor(orig_MarkerColor);
-    gStyle->SetPaintTextFormat(orig_PaintTextFormat) ;
-    gStyle->SetLabelSize(orig_LabelSize);
-    gStyle->SetOptStat(00000000);
-
     return h_corr;
 
 }

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -1559,13 +1559,31 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
           if (fillHistY) {
             h_corr_reduced->Fill(index_x,index_y,h_corr->GetBinContent(ix,iy));
             index_y++;
-            if (index_x==0) h_corr_reduced->GetYaxis()->SetBinLabel(index_y,h_corr->GetYaxis()->GetBinLabel(iy));
+            TString labelY = h_corr->GetYaxis()->GetBinLabel(iy);
+                  if(labelY.Contains("Lumi") || labelY.Contains("mcstat") || labelY.Contains("gamma_stat")){
+                  labelY.ReplaceAll("gamma_shape_mcstat","#gamma");
+                  labelY.ReplaceAll("gamma_stat","#gamma");
+                  labelY.ReplaceAll("_cuts_bin_0","");}
+                  if(labelY.Contains("mu")){
+                  labelY.ReplaceAll("mu","#mu");}
+                  if(labelY.Contains("alpha")){
+                  labelY.ReplaceAll("alpha","#alpha");}
+            if (index_x==0) h_corr_reduced->GetYaxis()->SetBinLabel(index_y,labelY);
             fillHistX=true;
           }
         }
         if (fillHistX) {
           index_x++;
-          h_corr_reduced->GetXaxis()->SetBinLabel(index_x,h_corr->GetXaxis()->GetBinLabel(ix));
+           TString labelX = h_corr->GetXaxis()->GetBinLabel(ix);
+                  if(labelX.Contains("Lumi") || labelX.Contains("mcstat") || labelX.Contains("gamma_stat")){
+                  labelX.ReplaceAll("gamma_shape_mcstat","#gamma");
+                  labelX.ReplaceAll("gamma_stat","#gamma");
+                  labelX.ReplaceAll("_cuts_bin_0","");}
+                  if(labelX.Contains("mu")){
+                  labelX.ReplaceAll("mu","#mu");}
+                  if(labelX.Contains("alpha")){
+                  labelX.ReplaceAll("alpha","#alpha");}
+          h_corr_reduced->GetXaxis()->SetBinLabel(index_x,labelX);
         }
       }
 


### PR DESCRIPTION
Update contourplotter.py:
- ROOT.Double() deprecated
- ROOT.Double() can't be switched to ctypes.c_double() as GetPoint() function needs real number. If I try to use ctypes.c_double(), I get TypeError: must be real number, not c_double, so I believe GetPointX and GetPointY are correct.