### PR TITLE
fix: Keep default user in Docker image as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN root --version && \
     cd src && \
     make -j$(($(nproc) - 1)) && \
     mkdir -p "${HOME}/.local/bin" && \
-    mkdir "${HOME}/data" && \
+    mkdir -p "${HOME}/data" && \
     printf '\nif [ -f /usr/local/HistFitter/setup.sh ];then\n    . /usr/local/HistFitter/setup.sh\nfi\n' >> "${HOME}/.profile"
 
 WORKDIR "${HOME}/data"


### PR DESCRIPTION
This avoids build problems and allows for write capabilities to volume mounts

**Suggested squash and merge commit message**:
```
* Set default user as root
   - If default user is non-root they will have no write capabilities to volume mounts
   - c.f. https://github.com/scailfin/MadGraph5_aMC-NLO/pull/39 for example
* Use `python` everywhere as the base image only supports Python 3
```