### PR TITLE
Fix suboptimal cache file check in prepareHistos

### DIFF
--- a/python/prepareHistos.py
+++ b/python/prepareHistos.py
@@ -17,7 +17,7 @@
  **********************************************************************************
 """
 
-from ROOT import gROOT, TFile, TH1D, gDirectory, SetOwnership
+from ROOT import gROOT, gSystem, TFile, TH1D, gDirectory, SetOwnership
 from ROOT import TChain, TObject, TTree, TIter
 from math import sqrt
 from logger import Logger
@@ -150,9 +150,13 @@ class PrepareHistos:
             self.cache2File = None
 
         # Check if cache file is accessible and not a zombie
-        self.cacheFile = TFile.Open(filepath, "READ")
+        cacheFileIsOk = False
+        if not gSystem.AccessPathName(filepath):            
+            self.cacheFile = TFile.Open(filepath, "READ")
+            if not self.cacheFile.IsZombie():
+                cacheFileIsOk = True
 
-        if (self.cacheFile) and (not self.cacheFile.IsZombie()):
+        if cacheFileIsOk:
             if file2path=='' and not self.useCacheToTreeFallback:
                 '''
                 default, no archive file and no fallback activated

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -3,7 +3,8 @@ def test_tutorial_MyUserAnalysis(script_runner):
     ret = script_runner(command)
 
     stderr = ret.stderr.read().decode("utf-8")
-    assert "data/MyUserAnalysis.root does not exist" in stderr
+
+    # n.b this Hesse is valid line doesn't  show up in ROOT 6.24, but does with 6.22
     assert (
         "Info in Minuit2Minimizer::Hesse : Hesse is valid - matrix is accurate"
         in stderr
@@ -11,5 +12,6 @@ def test_tutorial_MyUserAnalysis(script_runner):
     assert "results/MyUserAnalysis/fit_parameters.root has been created" in stderr
 
     stdout = ret.stdout.read().decode("utf-8")
+    assert "Status : MINIMIZE=0 HESSE=0" in stdout
     assert "HistFitter: Leaving HistFitter... Bye!" in stdout
     assert "* * * Welcome to HistFitter * * *" in stdout


### PR DESCRIPTION
The cache file check performed in prepareHistos will result in an error if the file does not exists. With this pull request the existence of the file is checked properly. 