### PR TITLE
Uniforming percentage notation in SysTableTex script

### DIFF
--- a/scripts/SysTableTex.py
+++ b/scripts/SysTableTex.py
@@ -93,7 +93,7 @@ Total background systematic              '''
           " & $\\pm "
           + str("%.2f" % m[region]["totsyserr"])
       )
-      if showPercent: tableline += r"\ [" + str("%.2f" % percentage) + "\\%] "
+      if showPercent: tableline += f"\ [{percentage:0.2f}\%] "
       tableline += "$       "
 
   tableline += '''      \\\\

--- a/scripts/SysTableTex.py
+++ b/scripts/SysTableTex.py
@@ -92,10 +92,9 @@ Total background systematic              '''
       tableline += (
           " & $\\pm "
           + str("%.2f" % m[region]["totsyserr"])
-          + r"\ ["
-          + str("%.2f" % percentage)
-          + "\\%] $       "
       )
+      if showPercent: tableline += r"\ [" + str("%.2f" % percentage) + "\\%] "
+      tableline += "$       "
 
   tableline += '''      \\\\
 \\midrule

--- a/scripts/SysTableTex.py
+++ b/scripts/SysTableTex.py
@@ -93,7 +93,7 @@ Total background systematic              '''
           " & $\\pm "
           + str("%.2f" % m[region]["totsyserr"])
       )
-      if showPercent: tableline += f"\ [{percentage:0.2f}\%] "
+      if showPercent: tableline += fr"\ [{percentage:0.2f}\%] "
       tableline += "$       "
 
   tableline += '''      \\\\


### PR DESCRIPTION
Currently, there is a flag to switch on/off the individual errors as percentage of the total systematic error. But the total background syst error was showing the percentage independently of the flag, so I just added an if-clause to have that line coherent with the rest of the code.

Please, let me know if the implementation is fine. Thanks in advance