### PR TITLE
Adds missing include guard and removes redundant function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ include/*.h
 results/*
 config/*
 data/*
+*.json
 
 # Development environments
 .vscode/

--- a/src/CombinationUtils.h
+++ b/src/CombinationUtils.h
@@ -14,8 +14,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef CombinationUtils_H
-#define CombinationUtils_H
+#ifndef COMBINATIONUTILS_H
+#define COMBINATIONUTILS_H
 
 #include <string>
 #include "TString.h"
@@ -30,15 +30,15 @@ class TTree;
 void resetFloatPars( const RooWorkspace* w, const RooFitResult* result );
 
 //________________________________________________________________________________________________
-namespace Util 
+namespace Util
 {
   /// From combination package
 
-  float getValueFromTree( TTree* tree, const std::string& searchpar, 
-                          const std::string& pn0="", const float& v0=-1, const std::string& pn1="", const float& v1=-1, 
-                          const std::string& pn2="", const float& v2=-1, const std::string& pn3="", const float& v3=-1, 
-                          const std::string& pn4="", const float& v4=-1, const std::string& pn5="", const float& v5=-1, 
-                          const std::string& pn6="", const float& v6=-1, const std::string& pn7="", const float& v7=-1, 
+  float getValueFromTree( TTree* tree, const std::string& searchpar,
+                          const std::string& pn0="", const float& v0=-1, const std::string& pn1="", const float& v1=-1,
+                          const std::string& pn2="", const float& v2=-1, const std::string& pn3="", const float& v3=-1,
+                          const std::string& pn4="", const float& v4=-1, const std::string& pn5="", const float& v5=-1,
+                          const std::string& pn6="", const float& v6=-1, const std::string& pn7="", const float& v7=-1,
                           const std::string& pn8="", const float& v8=-1, const std::string& pn9="", const float& v9=-1 );
 
   float getValueFromTree( TTree* tree, const std::string& searchpar, const std::vector<std::string>& pnVec, const std::vector<float>& vVec );

--- a/src/CombineWorkSpaces.cxx
+++ b/src/CombineWorkSpaces.cxx
@@ -60,9 +60,9 @@ void clearVec( std::vector<RooWorkspace*>& wsVec ) {
     //std::vector<RooWorkspace*>::iterator wItr=wsVec.begin(), wEnd=wsVec.end();
     //for (; wItr!=wEnd; ++wItr) {
     for(auto *wItr: wsVec) {
-        if ( wItr !=0) { 
-            delete (wItr); 
-        } 
+        if ( wItr !=0) {
+            delete (wItr);
+        }
     }
     wsVec.clear();
 }
@@ -81,7 +81,7 @@ std::vector<RooWorkspace*> CollectWorkspaces( const std::map< TString,TString >&
     for(auto const &wfItr : fwnameMap) {
         //for (int i=0; wfItr!=wfEnd; ++wfItr, ++i) {
         ++i;
-        RooWorkspace* w = GetWorkspaceFromFile( wfItr.first.Data(), wfItr.second );
+        RooWorkspace* w = Util::GetWorkspaceFromFile( wfItr.first.Data(), wfItr.second );
         if ( w==0 ) {
             CombineWorkSpacesLogger << kFATAL << "Cannot open workspace <" << wfItr.second << "> in file <" << wfItr.second << ">" << GEndl;
         }
@@ -97,7 +97,7 @@ return wsVec;
 
 
 //________________________________________________________________________________________________
-/* this function categorizes all workspaces found in infile, whose names match the format 
+/* this function categorizes all workspaces found in infile, whose names match the format
  * string, eg. "muSUSY10_3j_20pb_SU_%f_%f_0_3", where %f and %f are mapped onto the parameters "m0:m12"
  */
 std::map< TString,TString > GetMatchingWorkspaces( const TString& infile, const TString& theformat, const TString& interpretation, const TString& cutStr, const Int_t& fID, TTree* ORTree ) {
@@ -119,7 +119,7 @@ std::map< TString,TString > GetMatchingWorkspaces( const TString& infile, const 
     TString format = theformat;
     CombineWorkSpacesLogger << kDEBUG << " 1  format = " << format << GEndl;
     Bool_t searchFileName(kFALSE);
-    if (format.BeginsWith("filename+")) { 
+    if (format.BeginsWith("filename+")) {
         format = format.ReplaceAll("filename+","");
         searchFileName = kTRUE;
     }
@@ -181,7 +181,7 @@ std::map< TString,TString > GetMatchingWorkspaces( const TString& infile, const 
         wsnameSearch = wsname;
         CombineWorkSpacesLogger << kDEBUG <<" 5.1   j = " << j << " wsnameSearch = " << wsnameSearch << GEndl;
 
-        if (searchFileName && !fullWSName.IsNull()) { // E.g. WS is called combined 
+        if (searchFileName && !fullWSName.IsNull()) { // E.g. WS is called combined
             CombineWorkSpacesLogger << kDEBUG << " 5.2   searchFileName && !fullWSName.IsNull() = " << (searchFileName && !fullWSName.IsNull()) << GEndl;
             CombineWorkSpacesLogger << kDEBUG << " 5.3   TString(key->GetName())) = " << TString(key->GetName()) << GEndl;
             if (fullWSName != TString(key->GetName()))  continue;
@@ -192,41 +192,41 @@ std::map< TString,TString > GetMatchingWorkspaces( const TString& infile, const 
         //// -> we check for NULL when really reading anyway!
         //// confirm this is a workspace
         //TObject* obj = file->Get( wsname.Data() );
-        //if (obj==0) continue; 
+        //if (obj==0) continue;
         ////	if ( obj->ClassName()!=TString("RooWorkspace") ) continue;
 
         CombineWorkSpacesLogger << kDEBUG << " 5.4  searchFileName = " << searchFileName << GEndl;
         if (searchFileName) {
-            wsnameSearch = infile + "_" + wsnameSearch;	
+            wsnameSearch = infile + "_" + wsnameSearch;
         }
         CombineWorkSpacesLogger << kDEBUG << " 5.5  wsnameSearch = " << wsnameSearch << GEndl;
 
         // accept upto 10 args in ws name
-        int narg2 = sscanf( wsnameSearch.Data(), format.Data(), &wsarg[0],&wsarg[1],&wsarg[2],&wsarg[3],&wsarg[4],&wsarg[5],&wsarg[6],&wsarg[7],&wsarg[8],&wsarg[9] ); 
+        int narg2 = sscanf( wsnameSearch.Data(), format.Data(), &wsarg[0],&wsarg[1],&wsarg[2],&wsarg[3],&wsarg[4],&wsarg[5],&wsarg[6],&wsarg[7],&wsarg[8],&wsarg[9] );
         if ( !(narg1==narg2 && narg1==narg3 && narg2>0) ) { continue; }
 
         wsarg.resize(narg2);
         wsid.Clear();  // form unique ws id
-        for (int i=0; i<narg2; ++i) { 
+        for (int i=0; i<narg2; ++i) {
             objString = (TObjString*)iArr->At(i);
             // wsid  += Form("%s_%.2f_", objString->GetString().Data(), wsarg[i]);
             wsid  += Form("%s=%.2f_", objString->GetString().Data(), wsarg[i]);
             formula.SetValue(objString->GetString(),wsarg[i]);
-        }        
+        }
         //wsid += Form( "%d_",keymap[key->GetName()] );
         if (!formula.GetBoolValue()) continue;
 
         if ((ORTree!=0) && fID>=0) { // logical orring
             float searchVal(-1);
             bool found = Util::findValueFromTree(ORTree,"fID",searchVal,wsidvec,wsarg);
-            if (!found) 
+            if (!found)
                 continue;
-            if ( fID!=static_cast<int>(searchVal) ) 
-                continue; 
+            if ( fID!=static_cast<int>(searchVal) )
+                continue;
         }
 
         // NOTE: wsid always connects to highest key-index found in file!
-        wsidMap[wsid] = wsname;    
+        wsidMap[wsid] = wsname;
         CombineWorkSpacesLogger << kDEBUG  << " 5.6  wsidMap[ " << wsid << "] = " << wsname << GEndl;
     }
 
@@ -237,41 +237,6 @@ std::map< TString,TString > GetMatchingWorkspaces( const TString& infile, const 
 
     return wsidMap;
 }
-
-
-//________________________________________________________________________________________________
-RooWorkspace* GetWorkspaceFromFile( const TString& infile, const TString& wsname ) {
-    TFile* file = TFile::Open(infile.Data(), "READ");
-    if (file->IsZombie()) {
-        CombineWorkSpacesLogger << kERROR << "Cannot open file: " << infile << GEndl;
-        return NULL;
-    }
-    file->cd();
-
-    TObject* obj = file->Get( wsname.Data() ) ;
-    if (obj==0) {
-        CombineWorkSpacesLogger << kERROR << "Cannot open workspace <" << wsname << "> in file <" << infile << ">" << GEndl;
-        file->Close();
-        return NULL;
-    }
-
-    if (obj->ClassName()!=TString("RooWorkspace")) {
-        CombineWorkSpacesLogger << kERROR << "Cannot open workspace <" << wsname << "> in file <" << infile << ">" << GEndl;
-        file->Close();
-        return NULL;
-    }
-
-    RooWorkspace* w = (RooWorkspace*)( obj );
-    if ( w==0 ) {
-        CombineWorkSpacesLogger << kERROR << "Cannot open workspace <" << wsname << "> in file <" << infile << ">" << GEndl;
-        file->Close();
-        return NULL;
-    }
-
-    //file->Close();
-    return w;
-}
-
 
 //________________________________________________________________________________________________
 RooStats::HypoTestInverterResult* GetHypoTestResultFromFile( TFile* file, const TString& wsname ) {

--- a/src/CombineWorkSpaces.h
+++ b/src/CombineWorkSpaces.h
@@ -15,8 +15,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef CombineWorkSpaces_hh
-#define CombineWorkSpaces_hh
+#ifndef COMBINEWORKSPACES_H
+#define COMBINEWORKSPACES_H
 
 #include "TString.h"
 #include <string>
@@ -24,7 +24,7 @@
 #include <map>
 
 // -------------------------------
-// Combines workspaces 
+// Combines workspaces
 // -------------------------------
 
 class RooWorkspace;
@@ -43,8 +43,6 @@ std::map<TString,TString> GetMatchingWorkspaces( const TString& infile, const TS
 std::vector<RooWorkspace*> CollectWorkspaces( const std::map< TString,TString >& fwnameMap, const TString& wid );
 
 void clearVec( std::vector<RooWorkspace*>& wsVec );
-
-RooWorkspace* GetWorkspaceFromFile( const TString& infile, const TString& wsname );
 
 RooStats::HypoTestInverterResult* GetHypoTestResultFromFile( TFile* file, const TString& wsname );
 

--- a/src/DrawUtils.cxx
+++ b/src/DrawUtils.cxx
@@ -26,149 +26,149 @@
 using namespace std;
 
 
-namespace DrawUtil {
+namespace DrawUtil
+{
     static TMsgLogger DrawUtilLogger("DrawUtil");
-}
-
 
 //________________________________________________________________________________________________
-TH2D* DrawUtil::triwsmooth( TTree* tree, const char* varstr, const char* name, const char* title, const char* cutstr, TH2D* inputHist){
-    if (tree==NULL) 
-        return 0;
+    TH2D* triwsmooth( TTree* tree, const char* varstr, const char* name, const char* title, const char* cutstr, TH2D* inputHist) {
+        if (tree==NULL)
+            return 0;
 
-    int ntotal = tree->GetEntries("1");
-    int nselect = tree->GetEntries(cutstr);
+        int ntotal = tree->GetEntries("1");
+        int nselect = tree->GetEntries(cutstr);
 
-    DrawUtilLogger << kINFO << "Plotting " << varstr << " with selection " << cutstr << "." << GEndl; 
-    DrawUtilLogger << kINFO << "Selected " << nselect << " out of " << ntotal << " entries. Fraction = " << double(nselect)/ntotal << GEndl;
+        DrawUtilLogger << kINFO << "Plotting " << varstr << " with selection " << cutstr << "." << GEndl;
+        DrawUtilLogger << kINFO << "Selected " << nselect << " out of " << ntotal << " entries. Fraction = " << double(nselect)/ntotal << GEndl;
 
-    // Wacky workaround to prevent segfault in tree->Draw() below.
-    TString buh("");
-    bool goff __attribute__((unused)) = buh.Contains("goff");
+        // Wacky workaround to prevent segfault in tree->Draw() below.
+        TString buh("");
+        bool goff __attribute__((unused)) = buh.Contains("goff");
 
-    tree->Draw(varstr,cutstr,"goff");
-    Long64_t  nrows = tree->GetSelectedRows();
-    Double_t *v1 =  tree->GetV1();
-    Double_t *v2 = tree->GetV2();
-    Double_t *v3 = tree->GetV3();
+        tree->Draw(varstr,cutstr,"goff");
+        Long64_t  nrows = tree->GetSelectedRows();
+        Double_t *v1 =  tree->GetV1();
+        Double_t *v2 = tree->GetV2();
+        Double_t *v3 = tree->GetV3();
 
-    if (nselect == 0) 
-        return 0;
+        if (nselect == 0)
+            return 0;
 
-    TGraph2D* gr = new TGraph2D( nrows, v3, v2, v1 );
+        TGraph2D* gr = new TGraph2D( nrows, v3, v2, v1 );
 
-    gr->SetName(name!=0 ? TString(name)+"gr" : "graph2d");
-    gr->SetTitle(title!=0 ? TString(title)+"gr" : TString(varstr) + " drawn TRIW");
-    gr->Draw("TRIW");
+        gr->SetName(name!=0 ? TString(name)+"gr" : "graph2d");
+        gr->SetTitle(title!=0 ? TString(title)+"gr" : TString(varstr) + " drawn TRIW");
+        gr->Draw("TRIW");
 
-    if (inputHist!=NULL){
-        gr->SetHistogram(inputHist);
-    }
-
-    TH2D* foo = gr->GetHistogram();
-    TH2D* hist = (TH2D*)foo->Clone();
-
-    /// for some reason this doesn't work in cint?
-    hist->SetName(  name!=0 ? name : "hist" );
-    hist->SetTitle( title!=0 ? title : "hist title" );
-    delete gr; gr=0;
-
-    return hist; // note: caller owns histogram
-}
-
-
-//________________________________________________________________________________________________
-TH2F* DrawUtil::makesignificancehistos( TTree* tree, int mode,TString id1,TString id2,int   nbinsX,int nbinsY, float minX,float maxX, float minY, float maxY) {
-    if (tree == NULL) 
-        return 0;
-    
-    if (mode<0 || mode>2) 
-        return 0;
-
-    Float_t         m0;
-    Float_t         m12;
-    Float_t         p1;
-    Float_t         p0;
-    Float_t         sig;
-    Float_t         bkg;
-
-    TBranch         *b_m0;   //!
-    TBranch         *b_m12;  //!
-    TBranch         *b_p1;   //!
-    TBranch         *b_p0;   //!
-    TBranch         *b_sig;  //!
-    TBranch         *b_bkg;  //!
-
-    tree->SetBranchAddress(id1,  &m0,  &b_m0);
-    tree->SetBranchAddress(id2, &m12, &b_m12);
-    tree->SetBranchAddress("p1",  &p1,  &b_p1);
-    tree->SetBranchAddress("p0",  &p0,  &b_p0);
-    tree->SetBranchAddress("sig", &sig, &b_sig);
-    tree->SetBranchAddress("bkg", &bkg, &b_bkg);
-
-    TString bulkName = "SUSY_"+id1+"_vs_"+id2+"_Scan";
-
-    TH2F* hclPmin(0);
-    if (mode==0)   hclPmin   = new TH2F("hclPmin"     , bulkName + TString(" (1 - CL)"),    nbinsX, minX, maxX, nbinsY, minY, maxY );
-    TH2F* hsigPmin(0);
-    if (mode==1)   hsigPmin  = new TH2F("hsigPmin"    , bulkName + TString("sig"), nbinsX, minX, maxX, nbinsY, minY, maxY );
-    TH2F* hbkgPmin(0);
-    if (mode==2)   hbkgPmin  = new TH2F("hbkgPmin"    , bulkName + TString("bkg"), nbinsX, minX, maxX, nbinsY, minY, maxY );
-
-    // then: fill histograms
-    for( Int_t i = 0; i < tree->GetEntries(); i++ ){
-        tree->GetEntry( i );
-        //cout << " m0=" << m0 << " m12=" << m12 << " p1=" << p1 << GEndl;
-        if (mode==0) { hclPmin->Fill( m0, m12, p1 ); }
-        if (mode==1) { hsigPmin->Fill( m0, m12, sig ); }
-        if (mode==2) { hbkgPmin->Fill( m0, m12, bkg ); }
-    }
-
-    DrawUtilLogger << kINFO << "done filling bkg" << GEndl;
-
-    if (mode==0)  return hclPmin;
-    if (mode==1)  return hsigPmin;
-    if (mode==2)  return hbkgPmin;
-    else return 0;
-}
-
-
-//________________________________________________________________________________________________
-TH2F* DrawUtil::linearsmooth(const TH2& hist, const char* name, const char* title) {
-    int nbinsx = hist.GetNbinsX();
-    int nbinsy = hist.GetNbinsY();
-
-    double xbinwidth = ( hist.GetXaxis()->GetBinCenter(nbinsx) - hist.GetXaxis()->GetBinCenter(1) ) / double(nbinsx-1);
-    double ybinwidth = ( hist.GetYaxis()->GetBinCenter(nbinsy) - hist.GetYaxis()->GetBinCenter(1) ) / double(nbinsy-1);
-
-    int nbinsxsm = 2*nbinsx - 1 ;
-    int nbinsysm = 2*nbinsy - 1 ;
-
-    double xmin = hist.GetXaxis()->GetBinCenter(1) - xbinwidth/4. ;
-    double xmax = hist.GetXaxis()->GetBinCenter(nbinsx) + xbinwidth/4. ;
-    double ymin = hist.GetYaxis()->GetBinCenter(1) - ybinwidth/4. ;
-    double ymax = hist.GetYaxis()->GetBinCenter(nbinsy) + ybinwidth/4. ;
-
-    TH2F* hist2 = new TH2F(name, title, nbinsxsm, xmin, xmax, nbinsysm, ymin, ymax);
-
-    for (Int_t ibin1=1; ibin1 < hist.GetNbinsX(); ibin1++) {
-        for (Int_t ibin2=1; ibin2 < hist.GetNbinsY(); ibin2++) {
-            float f00 = hist.GetBinContent(ibin1,ibin2);
-            float f10 = hist.GetBinContent(ibin1+1,ibin2);
-            float f01 = hist.GetBinContent(ibin1,ibin2+1);
-            float f11 = hist.GetBinContent(ibin1+1,ibin2+1);
-
-            for (Int_t i=0; i<=2; ++i)
-                for (Int_t j=0; j<=2; ++j) {
-                    float x = i*0.5; float y = j*0.5;
-                    float val = (1-x)*(1-y)*f00 + x*(1-y)*f10 + (1-x)*y*f01 + x*y*f11 ;
-                    Int_t jbin1 = 2*ibin1 - 1 + i;
-                    Int_t jbin2 = 2*ibin2 - 1 + j;
-                    hist2->SetBinContent(jbin1,jbin2,val);
-                }
+        if (inputHist!=NULL){
+            gr->SetHistogram(inputHist);
         }
+
+        TH2D* foo = gr->GetHistogram();
+        TH2D* hist = (TH2D*)foo->Clone();
+
+        /// for some reason this doesn't work in cint?
+        hist->SetName(  name!=0 ? name : "hist" );
+        hist->SetTitle( title!=0 ? title : "hist title" );
+        delete gr; gr=0;
+
+        return hist; // note: caller owns histogram
     }
 
-    return hist2; // caller owns histogram
-}
 
+    //________________________________________________________________________________________________
+    TH2F* makesignificancehistos( TTree* tree, int mode,TString id1,TString id2,int   nbinsX,int nbinsY, float minX,float maxX, float minY, float maxY) {
+        if (tree == NULL)
+            return 0;
+
+        if (mode<0 || mode>2)
+            return 0;
+
+        Float_t         m0;
+        Float_t         m12;
+        Float_t         p1;
+        Float_t         p0;
+        Float_t         sig;
+        Float_t         bkg;
+
+        TBranch         *b_m0;   //!
+        TBranch         *b_m12;  //!
+        TBranch         *b_p1;   //!
+        TBranch         *b_p0;   //!
+        TBranch         *b_sig;  //!
+        TBranch         *b_bkg;  //!
+
+        tree->SetBranchAddress(id1,  &m0,  &b_m0);
+        tree->SetBranchAddress(id2, &m12, &b_m12);
+        tree->SetBranchAddress("p1",  &p1,  &b_p1);
+        tree->SetBranchAddress("p0",  &p0,  &b_p0);
+        tree->SetBranchAddress("sig", &sig, &b_sig);
+        tree->SetBranchAddress("bkg", &bkg, &b_bkg);
+
+        TString bulkName = "SUSY_"+id1+"_vs_"+id2+"_Scan";
+
+        TH2F* hclPmin(0);
+        if (mode==0)   hclPmin   = new TH2F("hclPmin"     , bulkName + TString(" (1 - CL)"),    nbinsX, minX, maxX, nbinsY, minY, maxY );
+        TH2F* hsigPmin(0);
+        if (mode==1)   hsigPmin  = new TH2F("hsigPmin"    , bulkName + TString("sig"), nbinsX, minX, maxX, nbinsY, minY, maxY );
+        TH2F* hbkgPmin(0);
+        if (mode==2)   hbkgPmin  = new TH2F("hbkgPmin"    , bulkName + TString("bkg"), nbinsX, minX, maxX, nbinsY, minY, maxY );
+
+        // then: fill histograms
+        for( Int_t i = 0; i < tree->GetEntries(); i++ ){
+            tree->GetEntry( i );
+            //cout << " m0=" << m0 << " m12=" << m12 << " p1=" << p1 << GEndl;
+            if (mode==0) { hclPmin->Fill( m0, m12, p1 ); }
+            if (mode==1) { hsigPmin->Fill( m0, m12, sig ); }
+            if (mode==2) { hbkgPmin->Fill( m0, m12, bkg ); }
+        }
+
+        DrawUtilLogger << kINFO << "done filling bkg" << GEndl;
+
+        if (mode==0)  return hclPmin;
+        if (mode==1)  return hsigPmin;
+        if (mode==2)  return hbkgPmin;
+        else return 0;
+    }
+
+
+    //________________________________________________________________________________________________
+    TH2F* linearsmooth(const TH2& hist, const char* name, const char* title) {
+        int nbinsx = hist.GetNbinsX();
+        int nbinsy = hist.GetNbinsY();
+
+        double xbinwidth = ( hist.GetXaxis()->GetBinCenter(nbinsx) - hist.GetXaxis()->GetBinCenter(1) ) / double(nbinsx-1);
+        double ybinwidth = ( hist.GetYaxis()->GetBinCenter(nbinsy) - hist.GetYaxis()->GetBinCenter(1) ) / double(nbinsy-1);
+
+        int nbinsxsm = 2*nbinsx - 1 ;
+        int nbinsysm = 2*nbinsy - 1 ;
+
+        double xmin = hist.GetXaxis()->GetBinCenter(1) - xbinwidth/4. ;
+        double xmax = hist.GetXaxis()->GetBinCenter(nbinsx) + xbinwidth/4. ;
+        double ymin = hist.GetYaxis()->GetBinCenter(1) - ybinwidth/4. ;
+        double ymax = hist.GetYaxis()->GetBinCenter(nbinsy) + ybinwidth/4. ;
+
+        TH2F* hist2 = new TH2F(name, title, nbinsxsm, xmin, xmax, nbinsysm, ymin, ymax);
+
+        for (Int_t ibin1=1; ibin1 < hist.GetNbinsX(); ibin1++) {
+            for (Int_t ibin2=1; ibin2 < hist.GetNbinsY(); ibin2++) {
+                float f00 = hist.GetBinContent(ibin1,ibin2);
+                float f10 = hist.GetBinContent(ibin1+1,ibin2);
+                float f01 = hist.GetBinContent(ibin1,ibin2+1);
+                float f11 = hist.GetBinContent(ibin1+1,ibin2+1);
+
+                for (Int_t i=0; i<=2; ++i)
+                    for (Int_t j=0; j<=2; ++j) {
+                        float x = i*0.5; float y = j*0.5;
+                        float val = (1-x)*(1-y)*f00 + x*(1-y)*f10 + (1-x)*y*f01 + x*y*f11 ;
+                        Int_t jbin1 = 2*ibin1 - 1 + i;
+                        Int_t jbin2 = 2*ibin2 - 1 + j;
+                        hist2->SetBinContent(jbin1,jbin2,val);
+                    }
+            }
+        }
+
+        return hist2; // caller owns histogram
+    }
+
+}

--- a/src/DrawUtils.h
+++ b/src/DrawUtils.h
@@ -14,6 +14,8 @@
  * modification, are permitted according to the terms listed in the file          *
  * LICENSE.                                                                       *
  **********************************************************************************/
+#ifndef DRAWUTILS_H
+#define DRAWUTILS_H
 
 #include "TString.h"
 class TTree;
@@ -21,10 +23,10 @@ class TH2F;
 class TH2D;
 class TH2;
 
-namespace DrawUtil 
+namespace DrawUtil
 {
     TH2D* triwsmooth( TTree* tree, const char* varstr, const char* name=0, const char* title=0, const char* cutstr="1", TH2D* inputHist=0);
     TH2F* makesignificancehistos(  TTree* tree, int mode, TString id1="m0",TString id2="m12", int   nbinsX=21,int nbinsY=17, float minX=20,float maxX=860, float minY=92.5, float maxY=347.5);
     TH2F* linearsmooth(const TH2& hist, const char* name=0, const char* title=0);
 }
-
+#endif

--- a/src/HistogramPlotter.cxx
+++ b/src/HistogramPlotter.cxx
@@ -50,7 +50,6 @@
 #include "RooMinimizer.h"
 #include "RooConstVar.h"
 #include "RooNumIntConfig.h"
-#include "RooMinuit.h"
 #include "RooBinningCategory.h"
 
 #include "TLegendEntry.h"
@@ -65,17 +64,17 @@ HistogramPlotter::HistogramPlotter(RooWorkspace *w, const TString& fitConfigName
     ConfigMgr* mgr = ConfigMgr::getInstance();
     FitConfig* fc = mgr->getFitConfig(fitConfigName);
     if(!w) {
-        throw std::invalid_argument( "No workspace passed" ); 
+        throw std::invalid_argument( "No workspace passed" );
     }
 
     if(!fc) {
-        throw std::invalid_argument( "No such fit configuration" ); 
+        throw std::invalid_argument( "No such fit configuration" );
     }
 
     m_workspace = w;
     m_fitConfig = fc;
 
-    m_plotRatio = mgr->m_plotRatio; 
+    m_plotRatio = mgr->m_plotRatio;
 
     m_plotRegions = "ALL";
     m_plotComponents = true;
@@ -87,18 +86,18 @@ HistogramPlotter::HistogramPlotter(RooWorkspace *w, const TString& fitConfigName
 
 HistogramPlotter::HistogramPlotter(RooWorkspace* w, FitConfig* fc) {
     if(!w) {
-        throw std::invalid_argument( "No workspace passed" ); 
+        throw std::invalid_argument( "No workspace passed" );
     }
 
     if(!fc) {
-        throw std::invalid_argument( "No such fit configuration" ); 
+        throw std::invalid_argument( "No such fit configuration" );
     }
 
     m_workspace = w;
     m_fitConfig = fc;
 
     ConfigMgr* mgr = ConfigMgr::getInstance();
-    m_plotRatio = mgr->m_plotRatio; 
+    m_plotRatio = mgr->m_plotRatio;
     m_plotRegions = "ALL";
 
 }
@@ -140,18 +139,18 @@ void HistogramPlotter::Initialize() {
     RooMsgService::instance().getStream(1).removeTopic(RooFit::Plotting);
 
     Logger << kINFO << "HistogramPlotter::Initialize()" << GEndl;
-    Logger << kINFO << " ------ Starting Plot with parameters:   analysisName = " << m_fitConfig->m_name << " and " << m_anaName << GEndl; 
+    Logger << kINFO << " ------ Starting Plot with parameters:   analysisName = " << m_fitConfig->m_name << " and " << m_anaName << GEndl;
     Logger << kINFO << "    plotRegions = '" <<  m_plotRegions <<  "'  plotComponents = " << m_plotComponents << "  outputPrefix = " << m_outputPrefix  << GEndl;
 
     m_pdf = static_cast<RooSimultaneous*>(m_workspace->pdf("simPdf"));
-    if(!m_inputData) { 
+    if(!m_inputData) {
         Logger << kDEBUG << "No data provided; loading from PDF" << GEndl;
         m_inputData = static_cast<RooAbsData*>(m_workspace->data("obsData"));
     }
 
     Logger << kDEBUG << "Loading RooCategory 'channelCat'" << GEndl;
     m_regionCategory = static_cast<RooCategory*>(m_workspace->cat("channelCat"));
-    
+
     Logger << kINFO << "Datasets found:" << GEndl;
     m_inputData->table(*(static_cast<RooAbsCategory*>(m_regionCategory)))->Print("v");
 
@@ -208,10 +207,10 @@ void HistogramPlotter::PlotRegion(const TString &regionCategoryLabel) {
     ChannelStyle style = m_fitConfig->getChannelStyle(regionCategoryLabel);
 
     // does this make sense?
-    if(!regionPdf || !regionData){ 
+    if(!regionPdf || !regionData){
         Logger << kWARNING << "Either the PDF or the dataset does not have an appropriate state for the region = " << regionCategoryLabel << ", check the workspace file" << GEndl;
-        Logger << kWARNING << "regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
-        return; 
+        Logger << kWARNING << "regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
+        return;
     }
 
     HistogramPlot plot(m_workspace, regionCategoryLabel, regionPdf, regionData, style);
@@ -232,10 +231,10 @@ void HistogramPlotter::PlotRegion(const TString &regionCategoryLabel) {
 ////////////////
 
 HistogramPlot::HistogramPlot(RooWorkspace *w,
-        const TString& regionCategoryLabel, RooAbsPdf *regionPdf, 
+        const TString& regionCategoryLabel, RooAbsPdf *regionPdf,
         RooDataSet *regionData, const ChannelStyle &style) : m_workspace(w),
     m_regionPdf(regionPdf),
-    m_regionData(regionData), 
+    m_regionData(regionData),
     m_style(style),
     m_regionCategoryLabel(regionCategoryLabel),
     m_regionVariableName("obs_x_"+regionCategoryLabel),
@@ -248,7 +247,7 @@ HistogramPlot::HistogramPlot(RooWorkspace *w,
 
     if (mgr->getRebinMap().find(std::string(m_regionCategoryLabel)) != mgr->getRebinMap().end())
         m_binEdges = mgr->getRebinMap()[std::string(m_regionCategoryLabel)];
-    
+
     m_fitResult = nullptr;
     m_plotComponents = false;
 }
@@ -270,7 +269,7 @@ void HistogramPlot::setFitResult(RooFitResult *r) {
 }
 
 void HistogramPlot::buildFrame() {
-    Logger << kINFO << "Building frame for " << m_regionCategoryLabel << GEndl; 
+    Logger << kINFO << "Building frame for " << m_regionCategoryLabel << GEndl;
 
     // create RooFit frame
     m_frame =  m_regionVariable->frame();
@@ -285,7 +284,7 @@ void HistogramPlot::buildFrame() {
             RooFit::XErrorSize(m_style.getXErrorSize()));
 
     }else m_regionData->plotOn(m_frame, RooFit::DataError(RooAbsData::Poisson),
-            RooFit::MarkerColor(m_style.getDataColor()), 
+            RooFit::MarkerColor(m_style.getDataColor()),
             RooFit::LineColor(m_style.getDataColor()));
 
     if(m_style.getRemoveEmptyBins()){
@@ -296,24 +295,24 @@ void HistogramPlot::buildFrame() {
     // normalize pdf to number of expected events, not to number of events in dataset
     Logger << kDEBUG << "Drawing PDF" << GEndl;
     m_regionPdf->plotOn(m_frame, RooFit::Normalization(1, RooAbsReal::RelativeExpected),
-            RooFit::Precision(1e-5), 
+            RooFit::Precision(1e-5),
             RooFit::LineColor(m_style.getTotalPdfColor()));
 
     // plot components
-    if(m_plotComponents) {  
+    if(m_plotComponents) {
         //AddComponentsToPlot(w, fc, frame, regionPdf, regionVar, regionCatLabel.Data(),style);
         addComponents();
     }
 
     // visualize error of fit
-    if(m_fitResult) { 	
+    if(m_fitResult) {
         Logger << kDEBUG << "Drawing fit errors" << GEndl;
-        m_regionPdf->plotOn(m_frame, RooFit::Normalization(1, RooAbsReal::RelativeExpected), 
-                RooFit::Precision(1e-5), 
-                RooFit::FillColor(m_style.getErrorFillColor()), 
+        m_regionPdf->plotOn(m_frame, RooFit::Normalization(1, RooAbsReal::RelativeExpected),
+                RooFit::Precision(1e-5),
+                RooFit::FillColor(m_style.getErrorFillColor()),
                 RooFit::FillStyle(m_style.getErrorFillStyle()),
                 RooFit::LineColor(m_style.getErrorLineColor()),
-                RooFit::LineStyle(m_style.getErrorLineStyle()), 
+                RooFit::LineStyle(m_style.getErrorLineStyle()),
                 RooFit::DrawOption("F"),
                 RooFit::VisualizeError(*m_fitResult),
                 RooFit::Name("total_error_band"));
@@ -323,7 +322,7 @@ void HistogramPlot::buildFrame() {
     // re-plot data and pdf, so they are on top of error and components
     Logger << kDEBUG << "Redrawing PDF" << GEndl;
     m_regionPdf->plotOn(m_frame, RooFit::Normalization(1, RooAbsReal::RelativeExpected),
-            RooFit::Precision(1e-5), 
+            RooFit::Precision(1e-5),
             RooFit::LineColor(m_style.getTotalPdfColor()));
 
     Logger << kDEBUG << "Redrawing data" << GEndl;
@@ -335,10 +334,10 @@ void HistogramPlot::buildFrame() {
             RooFit::XErrorSize(m_style.getXErrorSize()));
 
     } else  m_regionData->plotOn(m_frame, RooFit::DataError(RooAbsData::Poisson),
-            RooFit::MarkerColor(m_style.getDataColor()), 
+            RooFit::MarkerColor(m_style.getDataColor()),
             RooFit::LineColor(m_style.getDataColor()));
 
-    // remove any empty bins	
+    // remove any empty bins
     if(m_style.getRemoveEmptyBins()) {
         Logger << kDEBUG << "Removing empty bins" << GEndl;
         Util::RemoveEmptyDataBins(m_frame);
@@ -365,13 +364,13 @@ void HistogramPlot::addRatioPanelCosmetics(RooPlot* frame_dummy, RooPlot* frame)
     l4->SetLineStyle(3);
     l5->SetLineStyle(3);
 
-    TLine* lp1 = new TLine(xmin, 1., xmax, 1.);	
-    TLine* lp2 = new TLine(xmin, 2., xmax, 2.);	
+    TLine* lp1 = new TLine(xmin, 1., xmax, 1.);
+    TLine* lp2 = new TLine(xmin, 2., xmax, 2.);
     TLine* lp3 = new TLine(xmin, 3., xmax, 3.);
     TLine* lp4 = new TLine(xmin, 4., xmax, 4.);
     TLine* lp5 = new TLine(xmin, 5., xmax, 5.);
-    TLine* lp6 = new TLine(xmin, -1., xmax, -1.);	
-    TLine* lp7 = new TLine(xmin, -2., xmax, -2.);	
+    TLine* lp6 = new TLine(xmin, -1., xmax, -1.);
+    TLine* lp7 = new TLine(xmin, -2., xmax, -2.);
     TLine* lp8 = new TLine(xmin, -3., xmax, -3.);
     TLine* lp9 = new TLine(xmin, -4., xmax, -4.);
     TLine* lp10 = new TLine(xmin, -5., xmax, -5.);
@@ -387,7 +386,7 @@ void HistogramPlot::addRatioPanelCosmetics(RooPlot* frame_dummy, RooPlot* frame)
     lp9->SetLineStyle(3);
     lp10->SetLineStyle(3);
 
-    if(m_plotRatio == "ratio"){	
+    if(m_plotRatio == "ratio"){
         frame->addObject(l);
         frame->addObject(l2);
         frame->addObject(l3);
@@ -406,10 +405,10 @@ void HistogramPlot::addRatioPanelCosmetics(RooPlot* frame_dummy, RooPlot* frame)
         frame->addObject(lp10);
     }
 
-    Double_t lowerlimit = 0.; 
-    Double_t upperlimit = 2.2; 
-    if (m_plotRatio == "pull"){ 
-        lowerlimit = -5.7; 
+    Double_t lowerlimit = 0.;
+    Double_t upperlimit = 2.2;
+    if (m_plotRatio == "pull"){
+        lowerlimit = -5.7;
         upperlimit = 5.7;
     }
 
@@ -420,18 +419,18 @@ void HistogramPlot::addRatioPanelCosmetics(RooPlot* frame_dummy, RooPlot* frame)
 
 void HistogramPlot::addRatioPanel() {
     Logger << kDEBUG << "Adding ratio panel to plot" << GEndl;
-    
+
     //TFile f("/tmp/test.root", "recreate");
-    
+
     //std::cout << "pdf = " << m_regionData << std::endl;
     //std::cout << "data = " << m_regionPdf << std::endl;
     //std::cout << "variable = " << m_regionVariable << std::endl;
- 
+
     // Data/model ratio
     auto hratio = Util::MakeRatioOrPullHist(m_regionData, m_regionPdf, m_regionVariable);
     hratio->SetMarkerColor(m_style.getDataColor());
     hratio->SetLineColor(m_style.getDataColor());
-    
+
     // Data/bkg ratio -- check if we have a POI, if so, calculate the ratio with it set to 0
     RooStats::ModelConfig* mc = Util::GetModelConfig( m_workspace );
     const RooArgSet * poiSet = mc->GetParametersOfInterest();
@@ -456,12 +455,12 @@ void HistogramPlot::addRatioPanel() {
     }
 
     //// data/pdf ratio histograms are plotted by RooPlot.ratioHist() through a dummy frame
-    RooPlot* frame_dummy = m_regionVariable->frame(); 
+    RooPlot* frame_dummy = m_regionVariable->frame();
 
     // Construct a histogram with the ratio of the pdf curve w.r.t the pdf curve +/- 1 sigma
     RooCurve* hratioPdfError = new RooCurve;
     if (m_fitResult) {
-        hratioPdfError = Util::MakePdfErrorRatioHist(m_regionData, m_regionPdf, m_regionVariable, m_fitResult); 
+        hratioPdfError = Util::MakePdfErrorRatioHist(m_regionData, m_regionPdf, m_regionVariable, m_fitResult);
     }
     hratioPdfError->SetFillColor(m_style.getErrorFillColor());
     hratioPdfError->SetFillStyle(m_style.getErrorFillStyle());
@@ -470,22 +469,22 @@ void HistogramPlot::addRatioPanel() {
 
     // Create a new frame to draw the residual distribution and add the distribution to the frame
     RooPlot* frame2 = m_regionVariable->frame() ;
-    if(m_plotRatio == "ratio") { 
+    if(m_plotRatio == "ratio") {
         hratio->SetTitle("Ratio Distribution");
-    } else if(m_plotRatio == "pull") { 
-        hratio->SetTitle("Pull Distribution"); 
+    } else if(m_plotRatio == "pull") {
+        hratio->SetTitle("Pull Distribution");
     }
 
     // only add PdfErrorsPlot when the plot shows ratio, not with pull
-    if (m_fitResult && m_plotRatio == "ratio") { 
-        frame2->addPlotable(hratioPdfError, "F"); 
+    if (m_fitResult && m_plotRatio == "ratio") {
+        frame2->addPlotable(hratioPdfError, "F");
     }
-    
+
     // add the data/model ratio
     frame2->addPlotable(hratio, "P");
 
     // add the data/bkg ratio, if there was a POI to be set to 0
-    if(hratio_excl_sig) { 
+    if(hratio_excl_sig) {
         Logger << kWARNING << "Plotting second ratio" << GEndl;
         frame2->addPlotable(hratio_excl_sig, "P");
     }
@@ -498,11 +497,11 @@ void HistogramPlot::addRatioPanel() {
         frame2->GetYaxis()->SetTitle("Pull");
     }
 
-    if(m_style.getTitleX() != "") { 
+    if(m_style.getTitleX() != "") {
         frame2->GetXaxis()->SetTitle(m_style.getTitleX());
     }
 
-    //if(m_style.getTitleY() != "") { 
+    //if(m_style.getTitleY() != "") {
     //m_frame->GetYaxis()->SetTitle(m_style.getTitleY());
     //}
 
@@ -525,7 +524,7 @@ void HistogramPlot::addRatioPanel() {
     }
 
     frame2->GetYaxis()->SetLabelSize(0.13);
-    frame2->GetYaxis()->SetNdivisions(504);         
+    frame2->GetYaxis()->SetNdivisions(504);
     frame2->GetXaxis()->SetLabelSize(0.13);
     frame2->GetYaxis()->SetTitleSize(0.13);
     frame2->GetXaxis()->SetTitleSize(0.13);
@@ -536,7 +535,7 @@ void HistogramPlot::addRatioPanel() {
     frame2->GetXaxis()->SetTickLength(0.06);
 
     frame2->SetTitle("");
-    frame2->GetYaxis()->CenterTitle(); 
+    frame2->GetYaxis()->CenterTitle();
     frame2->Draw();
 
 }
@@ -545,7 +544,7 @@ void HistogramPlot::addComponents() {
     Logger << kDEBUG << "Adding components to plot" << GEndl;
 
     if(m_componentNames.empty()) {
-        loadComponentInformation(); 
+        loadComponentInformation();
     }
 
     const double normalisation = m_regionPdf->expectedEvents(*m_regionVariable);
@@ -563,11 +562,11 @@ void HistogramPlot::addComponents() {
         m_regionPdf->plotOn(m_frame, //RooFit::Normalization(1, RooAbsReal::RelativeExpected),
                 RooFit::Components(m_componentStackedNames[i].Data()),
                 RooFit::Normalization(m_componentStackedFractions[i]*normalisation, RooAbsReal::NumEvent),
-                RooFit::FillColor(color), 
+                RooFit::FillColor(color),
                 RooFit::FillStyle(1001),
                 RooFit::DrawOption("F"),
                 RooFit::Precision(1e-5));
-    } 
+    }
 
 }
 
@@ -594,15 +593,15 @@ void HistogramPlot::loadComponentInformation() {
     }
 
     // Now load the names and calculate the fractions to be able to build the plot
-    while( (component = dynamic_cast<RooProduct*>(iter.Next()))) { 
+    while( (component = dynamic_cast<RooProduct*>(iter.Next()))) {
         TString componentName(component->GetName());
 
         Logger << kDEBUG << "Identified component " << componentName << GEndl;
 
         // Build the stacked component names
-        TString stackedComponentName(componentName); 
+        TString stackedComponentName(componentName);
         if(!m_componentStackedNames.empty()){
-            stackedComponentName = Form("%s,%s", m_componentStackedNames.back().Data(), componentName.Data()); 
+            stackedComponentName = Form("%s,%s", m_componentStackedNames.back().Data(), componentName.Data());
         }
 
         m_componentNames.push_back(componentName);
@@ -611,10 +610,10 @@ void HistogramPlot::loadComponentInformation() {
         // Find the fraction and the stacked fraction for these backgrounds
         // RooFit can't stack via PlotOn() when normalising, so keep track of this ourselves
         double componentFraction = Util::GetComponentFrac(m_workspace, componentName, RSSPdfName, m_regionVariable, regionBinWidth) ;
-        double stackComponentFraction = componentFraction; 
+        double stackComponentFraction = componentFraction;
         if(!m_componentStackedFractions.empty()){
             stackComponentFraction  = m_componentStackedFractions.back() + componentFraction;
-        } 
+        }
 
         Logger << kVERBOSE << "Fraction = " << componentFraction << GEndl;
         Logger << kVERBOSE << "Stacked fraction = " << stackComponentFraction << GEndl;
@@ -656,7 +655,7 @@ TLegend* HistogramPlot::buildLegend() {
 
     // Load component info
     if(m_componentNames.empty()) {
-        loadComponentInformation(); 
+        loadComponentInformation();
     }
 
     // add components to legend
@@ -684,10 +683,10 @@ void HistogramPlot::plot() {
     // two pads, one for 'standard' plot, one for data/MC ratio
     float yMinP1 = 0.305;
     float bottomMarginP1 = 0.005;
-    if(m_plotRatio == "none"){ 
+    if(m_plotRatio == "none"){
         yMinP1 = 0.01;
         bottomMarginP1 = 0.09;
-    }	   
+    }
 
     // pad for standard plot
     TPad *pad1 = new TPad(Form("%s_pad1", canvasName.Data()), Form("%s_pad1", canvasName.Data()), 0., yMinP1, .99, 1);
@@ -703,8 +702,8 @@ void HistogramPlot::plot() {
     pad2->SetFillColor(kWhite);
 
     // Do we have a log plot?
-    if(m_style.getLogY()) { 
-        pad1->SetLogy(); 
+    if(m_style.getLogY()) {
+        pad1->SetLogy();
     }
 
     // Is there a title for the x-axis?
@@ -712,11 +711,11 @@ void HistogramPlot::plot() {
         m_frame->GetXaxis()->SetTitle(m_style.getTitleX());
     }
 
-    // Draw the pads	
+    // Draw the pads
     pad1->Draw();
-    if(m_plotRatio != "none"){ 
-        pad2->Draw(); 
-        m_frame->GetXaxis()->SetLabelSize(0.); 
+    if(m_plotRatio != "none"){
+        pad2->Draw();
+        m_frame->GetXaxis()->SetLabelSize(0.);
     }
 
     // Go to the main pad and set ranges for the frame
@@ -728,12 +727,12 @@ void HistogramPlot::plot() {
     }
 
     // now draw frame
-    m_frame->SetTitle(""); 
+    m_frame->SetTitle("");
     m_frame->Draw();
 
     // ATLAS string - FIXME: remove for public release
     if( (fabs(m_style.getATLASLabelX() + 1.) > 0.000001) and (fabs(m_style.getATLASLabelY() + 1.) > 0.000001) ) {
-        Util::ATLASLabel(m_style.getATLASLabelX(), m_style.getATLASLabelY(), m_style.getATLASLabelText()) ; 
+        Util::ATLASLabel(m_style.getATLASLabelX(), m_style.getATLASLabelY(), m_style.getATLASLabelText()) ;
     }
 
     // Lumi
@@ -744,7 +743,7 @@ void HistogramPlot::plot() {
     // Legend
     TLegend *legend = m_style.getTLegend();
     if(!legend) { legend = buildLegend(); }
-    legend->Draw(); 
+    legend->Draw();
 
     // Add ratio?
     if(m_plotRatio != "none") {
@@ -760,14 +759,14 @@ void HistogramPlot::plot() {
 
 void HistogramPlot::plotSeparateComponents() {
     if(m_componentNames.empty()) {
-        loadComponentInformation(); 
+        loadComponentInformation();
     }
 
     int nComponents = m_componentNames.size();
     if(nComponents == 0) {
         // this doesn't make any sense, so stop
         Logger << kWARNING << "No components found for '" << m_regionCategoryLabel << "' - returning." << GEndl;
-        return; 
+        return;
     }
 
     Logger << kDEBUG << "Will plot " << nComponents << " single components for " << m_regionCategoryLabel << GEndl;
@@ -799,22 +798,22 @@ void HistogramPlot::plotSeparateComponents() {
 
 void HistogramPlot::plotSingleComponent(unsigned int i, double normalisation) {
     if(m_componentNames.empty()) {
-        loadComponentInformation(); 
+        loadComponentInformation();
     }
 
     if(normalisation == 0.0) {
         normalisation = m_regionPdf->expectedEvents(*m_regionVariable);
     }
 
-    RooPlot* frame = m_regionVariable->frame(); 
+    RooPlot* frame = m_regionVariable->frame();
     frame->SetName(Form("frame_%s_%s_%s", m_regionCategoryLabel.Data(), m_componentNames[i].Data(), m_outputPrefix.Data()));
     auto color = m_style.getSampleColor(m_componentNames[i]);
     auto sampleName = m_style.getSampleName(m_componentNames[i]);
 
     Logger << kDEBUG << "Plotting single component " << sampleName << " for " << m_regionCategoryLabel << GEndl;
 
-    if (m_fitResult) { 
-        m_regionPdf->plotOn(frame, RooFit::Components(m_componentNames[i].Data()), 
+    if (m_fitResult) {
+        m_regionPdf->plotOn(frame, RooFit::Components(m_componentNames[i].Data()),
                 RooFit::VisualizeError(*m_fitResult),
                 RooFit::FillColor(kCyan),
                 RooFit::DrawOption("F"),
@@ -840,7 +839,7 @@ void HistogramPlot::plotSingleComponent(unsigned int i, double normalisation) {
     if(m_fitResult) {
         entry = leg->AddEntry("", "Propagated fit error", "f") ;
         entry->SetMarkerColor(kCyan);
-        entry->SetMarkerStyle();	
+        entry->SetMarkerStyle();
         entry->SetFillColor(kCyan);
         entry->SetFillStyle(1001);
     }
@@ -852,7 +851,7 @@ void HistogramPlot::plotSingleComponent(unsigned int i, double normalisation) {
 
 void HistogramPlot::saveHistograms() {
     if(m_componentNames.empty()) {
-        loadComponentInformation(); 
+        loadComponentInformation();
     }
 
     // Save the current directory to resume it after this function call
@@ -864,7 +863,7 @@ void HistogramPlot::saveHistograms() {
     TFile f(Form("results/%s/%s.root", m_anaName.Data(), canvasName.Data()), "update");
 
     // Data hist
-    RooPlot* frame_dummy = m_regionVariable->frame(); 
+    RooPlot* frame_dummy = m_regionVariable->frame();
     m_regionData->plotOn(frame_dummy, RooFit::DataError(RooAbsData::Poisson));
     auto data_hist = frame_dummy->findObject(nullptr, RooHist::Class());
     if (m_binEdges.size()) {
@@ -915,11 +914,11 @@ void HistogramPlot::saveHistograms() {
             hratio2 = static_cast<RooHist*>(g_hratio2);
         }
         hratio2->Write("h_ratio_excl_sig");
-        
+
         poi->setVal(poi_val_old);
     }
 
-    // Fit error for ratio, and the total fit error 
+    // Fit error for ratio, and the total fit error
     if (m_fitResult) {
         auto hratioPdfError = Util::MakePdfErrorRatioHist(m_regionData, m_regionPdf, m_regionVariable, m_fitResult);
         hratioPdfError->SetFillColor(m_style.getErrorFillColor());
@@ -934,12 +933,12 @@ void HistogramPlot::saveHistograms() {
 
         // We get the total error directly from RooFit
         // Needs to be drawn again for some reason; we cannot just get it from above and using m_frame
-        m_regionPdf->plotOn(frame_dummy, RooFit::Normalization(1, RooAbsReal::RelativeExpected), 
-                RooFit::Precision(1e-5), 
-                RooFit::FillColor(m_style.getErrorFillColor()), 
+        m_regionPdf->plotOn(frame_dummy, RooFit::Normalization(1, RooAbsReal::RelativeExpected),
+                RooFit::Precision(1e-5),
+                RooFit::FillColor(m_style.getErrorFillColor()),
                 RooFit::FillStyle(m_style.getErrorFillStyle()),
                 RooFit::LineColor(m_style.getErrorLineColor()),
-                RooFit::LineStyle(m_style.getErrorLineStyle()), 
+                RooFit::LineStyle(m_style.getErrorLineStyle()),
                 RooFit::DrawOption("F"),
                 RooFit::VisualizeError(*m_fitResult),
                 RooFit::Name("total_error_band"));
@@ -953,7 +952,7 @@ void HistogramPlot::saveHistograms() {
 
     // Every seperate component
     for(const auto& component: m_componentNames) {
-        auto h = Util::ComponentToHistogram(m_componentPdfs[component], m_regionVariable, m_fitResult); 
+        auto h = Util::ComponentToHistogram(m_componentPdfs[component], m_regionVariable, m_fitResult);
 
         h->SetFillColor(m_style.getSampleColor(component));
         h->SetName(m_style.getSampleName(component));

--- a/src/HistogramPlotter.h
+++ b/src/HistogramPlotter.h
@@ -1,6 +1,6 @@
 // vim: ts=4 sw=4
-#ifndef HAVE_HISTOGRAMPLOTTER_H
-#define HAVE_HISTOGRAMPLOTTER_H 
+#ifndef HISTOGRAMPLOTTER_H
+#define HISTOGRAMPLOTTER_H
 
 #include <iostream>
 #include <map>
@@ -84,7 +84,7 @@ class HistogramPlotter {
 
         // internals
         RooSimultaneous *m_pdf;
-        RooCategory *m_regionCategory; 
+        RooCategory *m_regionCategory;
         std::vector<TString> m_regions; // regions actually used for plotting
 
         std::vector< std::vector<TH1*> > m_histograms; // histograms
@@ -97,7 +97,7 @@ class HistogramPlot {
 
         void saveHistograms();
         void plotSeparateComponents();
-        
+
         void setAnalysisName(const TString& anaName);
         void setOutputPrefix(const TString& outputPrefix);
         void setFitResult(RooFitResult *r);
@@ -105,14 +105,14 @@ class HistogramPlot {
 
     private:
         HistogramPlot();
-       
+
         // for the 'normal' plot
         void buildFrame();
         void addRatioPanelCosmetics(RooPlot*, RooPlot*);
         void addRatioPanel();
         void addComponents();
 
-        // plot a single component 
+        // plot a single component
         void plotSingleComponent(unsigned int i, double normalisation=0.0);
 
         TLegend* buildLegend();
@@ -127,7 +127,7 @@ class HistogramPlot {
         RooAbsPdf* m_regionPdf;
         RooDataSet* m_regionData;
         ChannelStyle m_style;
-       
+
         RooFitResult* m_fitResult;
 
         TString m_regionCategoryLabel;

--- a/src/HypoTestTool.h
+++ b/src/HypoTestTool.h
@@ -17,13 +17,13 @@
  * Copyright (c):                                                                 *
  *      CERN, Switzerland                                                         *
  *                                                                                *
- * http://root.cern.ch/root/html534/tutorials/roostats/StandardHypoTestInvDemo.C.html 
+ * http://root.cern.ch/root/html534/tutorials/roostats/StandardHypoTestInvDemo.C.html
  *                                                                                *
  * (http://root.cern.ch/drupal/content/license)                                   *
  **********************************************************************************/
 
-#ifndef HypoTestTool_hh
-#define HypoTestTool_hh
+#ifndef HYPOTESTTOOL_H
+#define HYPOTESTTOOL_H
 
 #include <string>
 
@@ -40,7 +40,7 @@ class RooWorkspace;
 
 // internal class to run the inverter and more
 
-namespace RooStats { 
+namespace RooStats {
 
     class HypoTestTool{
 
@@ -48,27 +48,27 @@ namespace RooStats {
             HypoTestTool();
             ~HypoTestTool() { this->ResetHypoTestInverter(); this->ResetHypoTestCalculator(); };
 
-            HypoTestInverterResult* RunHypoTestInverter(RooWorkspace * w, 
-                        const char * modelSBName, const char * modelBName, 
+            HypoTestInverterResult* RunHypoTestInverter(RooWorkspace * w,
+                        const char * modelSBName, const char * modelBName,
                         const char * dataName,
-                        int type,  int testStatType, 
-                        bool useCLs, int npoints, double poimin, double poimax, int ntoys, 
-                        bool useNumberCounting = false, 
+                        int type,  int testStatType,
+                        bool useCLs, int npoints, double poimin, double poimax, int ntoys,
+                        bool useNumberCounting = false,
                         const char * nuisPriorName = 0);
 
-            HypoTestResult* RunHypoTest(RooWorkspace * w, bool doUL=true, 
-                        const char * modelSBName="ModelConfig", const char * modelBName="", 
+            HypoTestResult* RunHypoTest(RooWorkspace * w, bool doUL=true,
+                        const char * modelSBName="ModelConfig", const char * modelBName="",
                         const char * dataName="obsData",
-                        int type=0,  int testStatType=3, 
-                        int ntoys=1000, 
-                        bool useNumberCounting = false, 
+                        int type=0,  int testStatType=3,
+                        int ntoys=1000,
+                        bool useNumberCounting = false,
                         const char * nuisPriorName = 0);
 
             void AnalyzeResult( HypoTestInverterResult * r,
                         int calculatorType,
-                        int testStatType, 
-                        bool useCLs,  
-                        int npoints, 
+                        int testStatType,
+                        bool useCLs,
+                        int npoints,
                         const char* outfilePrefix = "",
                         const char* outfiletype = ".eps" ); ///,const char * fileNameBase = 0 );
 
@@ -81,21 +81,21 @@ namespace RooStats {
             inline HypoTestInverter* GetInverter() { return m_calc; }
 
         private:
-            bool SetupHypoTestInverter(RooWorkspace * w, 
-                    const char * modelSBName="ModelConfig", const char * modelBName="", 
+            bool SetupHypoTestInverter(RooWorkspace * w,
+                    const char * modelSBName="ModelConfig", const char * modelBName="",
                     const char * dataName="obsData",
-                    int type=0,  int testStatType=3, 
-                    bool useCLs=true, 
-                    int npoints=6, double poimin=0, double poimax=5, int ntoys=1000, 
-                    bool useNumberCounting = false, 
+                    int type=0,  int testStatType=3,
+                    bool useCLs=true,
+                    int npoints=6, double poimin=0, double poimax=5, int ntoys=1000,
+                    bool useNumberCounting = false,
                     const char * nuisPriorName = 0);
 
-            bool SetupHypoTestCalculator(RooWorkspace * w, bool doUL=true, 
-                    const char * modelSBName="ModelConfig", const char *modelBName="", 
+            bool SetupHypoTestCalculator(RooWorkspace * w, bool doUL=true,
+                    const char * modelSBName="ModelConfig", const char *modelBName="",
                     const char * dataName="obsData",
-                    int type=0,  int testStatType=3, 
-                    int ntoys=1000, 
-                    bool useNumberCounting = false, 
+                    int type=0,  int testStatType=3,
+                    int ntoys=1000,
+                    bool useNumberCounting = false,
                     const char * nuisPriorName = 0);
 
             inline void ResetHypoTestCalculator() { if (m_hc!=0) { delete m_hc; m_hc=0; } };
@@ -115,13 +115,13 @@ namespace RooStats {
             int     mNWorkers;
             int     mNToyToRebuild;
             int     mPrintLevel;
-            int     mInitialFit; 
-            int     mRandomSeed; 
+            int     mInitialFit;
+            int     mRandomSeed;
             double  mNToysRatio;
             double  mMaxPoi;
             std::string mMassValue;
-            std::string mMinimizerType;  
-            TString     mResultFileName; 
+            std::string mMinimizerType;
+            TString     mResultFileName;
 
             bool mNoSystematics;
             double mConfLevel;

--- a/src/LimitResult.h
+++ b/src/LimitResult.h
@@ -15,8 +15,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef LimitResult_hh
-#define LimitResult_hh
+#ifndef LIMITRESULT_H
+#define LIMITRESULT_H
 
 #include <iostream>
 #include <map>
@@ -64,19 +64,19 @@ class LimitResult {
 
         double GetP0() const 				{ return m_p0; }; // p value at signal = 0
         double GetP0exp() const 			{ return m_p0exp; }; //
-        double GetP0u1S() const 			{ return m_p0u1S; }; // 1 sigma upper and lower 
-        double GetP0d1S() const 			{ return m_p0d1S; }; // from toys               
-        double GetP0u2S() const                         { return m_p0u2S; }; // 1 sigma upper and lower 
-        double GetP0d2S() const                         { return m_p0d2S; }; // from toys               
+        double GetP0u1S() const 			{ return m_p0u1S; }; // 1 sigma upper and lower
+        double GetP0d1S() const 			{ return m_p0d1S; }; // from toys
+        double GetP0u2S() const                         { return m_p0u2S; }; // 1 sigma upper and lower
+        double GetP0d2S() const                         { return m_p0d2S; }; // from toys
 
         double GetP1() const 				{ return m_p1; }; // p value at signal = 1
 
-        double GetCLs() const 			{ return m_CLs; }; // 
+        double GetCLs() const 			{ return m_CLs; }; //
         double GetCLsexp() const 			{ return m_CLsexp; }; //
-        double GetCLsu1S() const 			{ return m_CLsu1S; }; // 1 sigma upper and lower 
-        double GetCLsd1S() const 			{ return m_CLsd1S; }; // from toys               
-        double GetCLsu2S() const                       { return m_CLsu2S; }; // 1 sigma upper and lower 
-        double GetCLsd2S() const                       { return m_CLsd2S; }; // from toys               
+        double GetCLsu1S() const 			{ return m_CLsu1S; }; // 1 sigma upper and lower
+        double GetCLsd1S() const 			{ return m_CLsd1S; }; // from toys
+        double GetCLsu2S() const                       { return m_CLsu2S; }; // 1 sigma upper and lower
+        double GetCLsd2S() const                       { return m_CLsd2S; }; // from toys
 
         double GetSigma0() const                      { return m_sigma0; }
         double GetSigma1() const                      { return m_sigma1; }
@@ -96,21 +96,21 @@ class LimitResult {
         double GetExpectedUpperLimitMinus2Sig() const              { return m_expectedUpperLimitMinus2Sig; }
 
 
-        void SetP0(double val)		{ m_p0 = val; }; // 
-        void SetP0exp(double val)	{ m_p0exp = val; }; // 
-        void SetP0u1S(double val)	{ m_p0u1S= val; }; // 1 sigma upper and lower 
-        void SetP0d1S(double val)	{ m_p0d1S= val; }; // from toys                  
-        void SetP0u2S(double val)        { m_p0u2S= val; }; // 1 sigma upper and lower 
-        void SetP0d2S(double val)        { m_p0d2S= val; }; // from toys        
+        void SetP0(double val)		{ m_p0 = val; }; //
+        void SetP0exp(double val)	{ m_p0exp = val; }; //
+        void SetP0u1S(double val)	{ m_p0u1S= val; }; // 1 sigma upper and lower
+        void SetP0d1S(double val)	{ m_p0d1S= val; }; // from toys
+        void SetP0u2S(double val)        { m_p0u2S= val; }; // 1 sigma upper and lower
+        void SetP0d2S(double val)        { m_p0d2S= val; }; // from toys
 
-        void SetP1(double val)		{ m_p1 = val; }; // 
+        void SetP1(double val)		{ m_p1 = val; }; //
 
-        void SetCLs(double val)		{ m_CLs = val; }; // 
-        void SetCLsexp(double val)		{ m_CLsexp = val; }; // 
-        void SetCLsu1S(double val)		{ m_CLsu1S= val; }; // 1 sigma upper and lower 
-        void SetCLsd1S(double val)		{ m_CLsd1S= val; }; // from toys                  
-        void SetCLsu2S(double val)             { m_CLsu2S= val; }; // 1 sigma upper and lower 
-        void SetCLsd2S(double val)             { m_CLsd2S= val; }; // from toys        
+        void SetCLs(double val)		{ m_CLs = val; }; //
+        void SetCLsexp(double val)		{ m_CLsexp = val; }; //
+        void SetCLsu1S(double val)		{ m_CLsu1S= val; }; // 1 sigma upper and lower
+        void SetCLsd1S(double val)		{ m_CLsd1S= val; }; // from toys
+        void SetCLsu2S(double val)             { m_CLsu2S= val; }; // 1 sigma upper and lower
+        void SetCLsd2S(double val)             { m_CLsd2S= val; }; // from toys
 
         void SetSigma0(const double& sigma)           { m_sigma0=sigma; };
         void SetSigma1(const double& sigma)           { m_sigma1=sigma; };
@@ -133,19 +133,19 @@ class LimitResult {
         // filename of saved file
         std::string GetResultFilename() const 		{ return m_resultfilename; }
         // comment string
-        std::string GetComments() const 			{ return m_comments; }   
+        std::string GetComments() const 			{ return m_comments; }
         // filename of saved file
         void SetResultFilename(const std::string & val)   { m_resultfilename = val; }
         // comment string
-        void SetComments(const std::string & val) 	{ m_comments = val; }   
+        void SetComments(const std::string & val) 	{ m_comments = val; }
 
         void Summary();
         std::vector<std::string> GetKeys() const;
         std::map<std::string, float> GetData() const;
-        JSON GetJSONData() const; 
-        std::string GetSummaryString() const; 
+        JSON GetJSONData() const;
+        std::string GetSummaryString() const;
         std::string GetDescriptionString() const;
-        void AddMetaData(const std::map<std::string,float>& metadata); 
+        void AddMetaData(const std::map<std::string,float>& metadata);
         void AddMetaData(const std::string&, float);
 };
 

--- a/src/RooHist.h
+++ b/src/RooHist.h
@@ -19,8 +19,8 @@
  * (http://roofit.sourceforge.net/license.txt)                               *
  *****************************************************************************/
 
-#ifndef ROO_HIST
-#define ROO_HIST
+#ifndef ROOHIST_H
+#define ROOHIST_H
 
 #include "TGraphAsymmErrors.h"
 #include "RooPlotable.h"
@@ -35,21 +35,21 @@ class RooHist : public TGraphAsymmErrors, public RooPlotable {
 public:
   RooHist() ;
   RooHist(Double_t nominalBinWidth, Double_t nSigma= 1, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);
-  RooHist(const TH1 &data, Double_t nominalBinWidth= 0, Double_t nSigma= 1, RooAbsData::ErrorType=RooAbsData::Poisson, 
+  RooHist(const TH1 &data, Double_t nominalBinWidth= 0, Double_t nSigma= 1, RooAbsData::ErrorType=RooAbsData::Poisson,
 	  Double_t xErrorFrac=1.0, Bool_t correctForBinWidth=kTRUE, Double_t scaleFactor=1.);
   RooHist(const TH1 &data1, const TH1 &data2, Double_t nominalBinWidth= 0, Double_t nSigma= 1, RooAbsData::ErrorType=RooAbsData::Poisson,
 	  Double_t xErrorFrac=1.0, Bool_t efficiency=kFALSE, Double_t scaleFactor=1.0);
-  RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1=1.0, Double_t wgt2=1.0, 
+  RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1=1.0, Double_t wgt2=1.0,
 	  RooAbsData::ErrorType etype=RooAbsData::Poisson, Double_t xErrorFrac=1.0) ;
   virtual ~RooHist();
 
   // add a datapoint for a bin with n entries, using a Poisson error
   void addBin(Axis_t binCenter, Double_t n, Double_t binWidth= 0, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);
   // add a datapoint for a bin with n entries, using a given error
-  void addBinWithError(Axis_t binCenter, Double_t n, Double_t elow, Double_t ehigh, Double_t binWidth= 0, 
+  void addBinWithError(Axis_t binCenter, Double_t n, Double_t elow, Double_t ehigh, Double_t binWidth= 0,
 		       Double_t xErrorFrac=1.0, Bool_t correctForBinWidth=kTRUE, Double_t scaleFactor=1.0);
   // add a datapoint for a bin with n entries, using a given x and y error
-  void addBinWithXYError(Axis_t binCenter, Double_t n, Double_t exlow, Double_t exhigh, Double_t eylow, Double_t eyhigh, 
+  void addBinWithXYError(Axis_t binCenter, Double_t n, Double_t exlow, Double_t exhigh, Double_t eylow, Double_t eyhigh,
                          Double_t scaleFactor=1.0);
   // add a datapoint for the asymmetry (n1-n2)/(n1+n2), using a binomial error
   void addAsymmetryBin(Axis_t binCenter, Int_t n1, Int_t n2, Double_t binWidth= 0, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);
@@ -75,16 +75,16 @@ public:
   Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const ;
   Double_t getFitRangeBinW() const;
   inline Double_t getNominalBinWidth() const { return _nominalBinWidth; }
-  inline void setRawEntries(Double_t n) { _rawEntries = n ; } 
+  inline void setRawEntries(Double_t n) { _rawEntries = n ; }
 
   Bool_t hasIdenticalBinning(const RooHist& other) const ;
 
   RooHist* makeResidHist(const RooCurve& curve,bool normalize=false, bool useAverage=false, bool returnRatio=false) const;
-  RooHist* makePullHist(const RooCurve& curve, bool useAverage=false) const 
+  RooHist* makePullHist(const RooCurve& curve, bool useAverage=false) const
     {return makeResidHist(curve,true,useAverage); }
-  RooHist* makeRatioHist(const RooCurve& curve, bool useAverage) const 
+  RooHist* makeRatioHist(const RooCurve& curve, bool useAverage) const
     {return makeResidHist(curve,true,useAverage,true); }
-  
+
 
 
   Bool_t isIdentical(const RooHist& other, Double_t tol=1e-6) const ;

--- a/src/RooHist.h
+++ b/src/RooHist.h
@@ -19,8 +19,8 @@
  * (http://roofit.sourceforge.net/license.txt)                               *
  *****************************************************************************/
 
-#ifndef ROOHIST_H
-#define ROOHIST_H
+#ifndef ROO_HIST
+#define ROO_HIST
 
 #include "TGraphAsymmErrors.h"
 #include "RooPlotable.h"

--- a/src/RooPlot.h
+++ b/src/RooPlot.h
@@ -19,8 +19,8 @@
  * (http://roofit.sourceforge.net/license.txt)                               *
  *****************************************************************************/
 
-#ifndef ROOPLOT_H
-#define ROOPLOT_H
+#ifndef ROO_PLOT
+#define ROO_PLOT
 
 #include <float.h>
 #include "RooList.h"

--- a/src/RooPlot.h
+++ b/src/RooPlot.h
@@ -19,8 +19,8 @@
  * (http://roofit.sourceforge.net/license.txt)                               *
  *****************************************************************************/
 
-#ifndef ROO_PLOT
-#define ROO_PLOT
+#ifndef ROOPLOT_H
+#define ROOPLOT_H
 
 #include <float.h>
 #include "RooList.h"
@@ -78,37 +78,37 @@ public:
   void SetAxisRange(Double_t xmin, Double_t xmax, Option_t* axis = "X") ;
   void SetBarOffset(Float_t offset = 0.25) ;
   void SetBarWidth(Float_t width = 0.5) ;
-  void SetContour(Int_t nlevels, const Double_t* levels = 0) ; 
-  void SetContourLevel(Int_t level, Double_t value) ; 
-  void SetDrawOption(Option_t* option = "") ; 
-  void SetFillAttributes() ; 
-  void SetFillColor(Color_t fcolor) ; 
-  void SetFillStyle(Style_t fstyle) ; 
-  void SetLabelColor(Color_t color = 1, Option_t* axis = "X") ; 
-  void SetLabelFont(Style_t font = 62, Option_t* axis = "X") ; 
-  void SetLabelOffset(Float_t offset = 0.005, Option_t* axis = "X") ; 
-  void SetLabelSize(Float_t size = 0.02, Option_t* axis = "X") ; 
-  void SetLineAttributes() ; 
-  void SetLineColor(Color_t lcolor) ; 
-  void SetLineStyle(Style_t lstyle) ; 
-  void SetLineWidth(Width_t lwidth) ; 
-  void SetMarkerAttributes() ; 
-  void SetMarkerColor(Color_t tcolor = 1) ; 
-  void SetMarkerSize(Size_t msize = 1) ; 
-  void SetMarkerStyle(Style_t mstyle = 1) ; 
+  void SetContour(Int_t nlevels, const Double_t* levels = 0) ;
+  void SetContourLevel(Int_t level, Double_t value) ;
+  void SetDrawOption(Option_t* option = "") ;
+  void SetFillAttributes() ;
+  void SetFillColor(Color_t fcolor) ;
+  void SetFillStyle(Style_t fstyle) ;
+  void SetLabelColor(Color_t color = 1, Option_t* axis = "X") ;
+  void SetLabelFont(Style_t font = 62, Option_t* axis = "X") ;
+  void SetLabelOffset(Float_t offset = 0.005, Option_t* axis = "X") ;
+  void SetLabelSize(Float_t size = 0.02, Option_t* axis = "X") ;
+  void SetLineAttributes() ;
+  void SetLineColor(Color_t lcolor) ;
+  void SetLineStyle(Style_t lstyle) ;
+  void SetLineWidth(Width_t lwidth) ;
+  void SetMarkerAttributes() ;
+  void SetMarkerColor(Color_t tcolor = 1) ;
+  void SetMarkerSize(Size_t msize = 1) ;
+  void SetMarkerStyle(Style_t mstyle = 1) ;
   void SetName(const char *name) ;
   void SetTitle(const char *name) ;
   void SetNameTitle(const char *name, const char* title) ;
-  void SetNdivisions(Int_t n = 510, Option_t* axis = "X") ; 
-  void SetOption(Option_t* option = " ") ; 
-  void SetStats(Bool_t stats = kTRUE) ; 
-  void SetTickLength(Float_t length = 0.02, Option_t* axis = "X") ; 
-  void SetTitleFont(Style_t font = 62, Option_t* axis = "X") ; 
-  void SetTitleOffset(Float_t offset = 1, Option_t* axis = "X") ; 
-  void SetTitleSize(Float_t size = 0.02, Option_t* axis = "X") ; 
-  void SetXTitle(const char* title) ; 
-  void SetYTitle(const char* title) ; 
-  void SetZTitle(const char* title) ; 
+  void SetNdivisions(Int_t n = 510, Option_t* axis = "X") ;
+  void SetOption(Option_t* option = " ") ;
+  void SetStats(Bool_t stats = kTRUE) ;
+  void SetTickLength(Float_t length = 0.02, Option_t* axis = "X") ;
+  void SetTitleFont(Style_t font = 62, Option_t* axis = "X") ;
+  void SetTitleOffset(Float_t offset = 1, Option_t* axis = "X") ;
+  void SetTitleSize(Float_t size = 0.02, Option_t* axis = "X") ;
+  void SetXTitle(const char* title) ;
+  void SetYTitle(const char* title) ;
+  void SetZTitle(const char* title) ;
 
   // container management
   const char* nameOf(Int_t idx) const ;
@@ -166,18 +166,18 @@ public:
   Bool_t setDrawOptions(const char *name, TString options);
 
   Bool_t getInvisible(const char* name) const ;
-  void setInvisible(const char* name, Bool_t flag=kTRUE) ; 
- 
+  void setInvisible(const char* name, Bool_t flag=kTRUE) ;
+
   virtual void SetMaximum(Double_t maximum = -1111) ;
   virtual void SetMinimum(Double_t minimum = -1111) ;
 
-  Double_t chiSquare(int nFitParam=0) const { return chiSquare(0, 0, nFitParam) ; } 
+  Double_t chiSquare(int nFitParam=0) const { return chiSquare(0, 0, nFitParam) ; }
   Double_t chiSquare(const char* pdfname, const char* histname, int nFitParam=0) const ;
 
   RooHist* residHist(const char* histname=0, const char* pdfname=0,bool normalize=false, bool useAverage=kFALSE,  bool returnRatio=false) const ;
-  RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=false) const 
+  RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=false) const
     { return residHist(histname, pdfname, true, useAverage); }
-  RooHist* ratioHist(const char* histname=0, const char* pdfname=0, bool useAverage=false) const 
+  RooHist* ratioHist(const char* histname=0, const char* pdfname=0, bool useAverage=false) const
     { return residHist(histname, pdfname, false, useAverage, true); }
 
   void Browse(TBrowser *b) ;
@@ -199,7 +199,7 @@ protected:
 
 
   void initialize();
-  TString histName() const ; 
+  TString histName() const ;
   TString caller(const char *method) const;
   void updateYAxis(Double_t ymin, Double_t ymax, const char *label= "");
   void updateFitRangeNorm(const TH1* hist);

--- a/src/Significance.h
+++ b/src/Significance.h
@@ -16,8 +16,8 @@
  * See corresponding .h file for author and license information                   *
  **********************************************************************************/
 
-#ifndef __Significance__
-#define __Significance__ 
+#ifndef SIGNIFICANCE_H
+#define SIGNIFICANCE_H
 
 #include "TString.h"
 #include <vector>
@@ -43,7 +43,7 @@ namespace StatTools
     Double_t FindXS95( Double_t nObs, Double_t nBkgExp, Double_t nBkgErr, Double_t signalEff, Double_t lumi, Double_t pValue=0.05 );
 
     Double_t FindSNSigma( Double_t nEvtExp, Double_t sumErr, Double_t nsigma3=3.0, Double_t signald=0, Double_t signalu=100, Double_t tol=0.001 ) ;
-    Double_t FindXSNSigma( Double_t nBkgExp, Double_t nBkgErr, Double_t signalEff, Double_t lumi, Double_t nsigma3=3.0, 
+    Double_t FindXSNSigma( Double_t nBkgExp, Double_t nBkgErr, Double_t signalEff, Double_t lumi, Double_t nsigma3=3.0,
             Double_t signalu=100 ) ;
 }
 

--- a/src/StatTools.h
+++ b/src/StatTools.h
@@ -1,6 +1,6 @@
 // vim: ts=4:sw=4
-#ifndef StatTools_hh
-#define StatTools_hh
+#ifndef STATTOOLS_H
+#define STATTOOLS_H
 
 #include "TString.h"
 #include <iostream>
@@ -30,25 +30,25 @@ namespace RooStats {
     class ModelConfig;
 }
 
-namespace RooStats 
+namespace RooStats
 {
-    TTree* toyMC_gen_fit( RooWorkspace* w, const int& nexp, const double& muVal=-1.0, const bool& doDataFitFirst=true, 
+    TTree* toyMC_gen_fit( RooWorkspace* w, const int& nexp, const double& muVal=-1.0, const bool& doDataFitFirst=true,
             const bool& storetoys=false, const TString& toyoutfile="toyResults.root" );
     TTree* ConvertMCStudyResults( RooMCStudy* mcstudy );
 
     RooStats::HypoTestInverterResult* DoHypoTestInversion( RooWorkspace* w,
                 int ntoys=1000,
                 int calculatorType = 0,
-                int testStatType = 3, 
-                bool useCLs = true ,  
-                int npoints = 1,   
-                double poimin = 1.0,  
-                double poimax = 1.0, 
+                int testStatType = 3,
+                bool useCLs = true ,
+                int npoints = 1,
+                double poimin = 1.0,
+                double poimax = 1.0,
                 bool doAnalyze = false,
                 bool useNumberCounting = false,
                 const char * modelSBName = "ModelConfig",
                 const char * modelBName = "",
-                const char * dataName = "obsData",                 
+                const char * dataName = "obsData",
                 const char * nuisPriorName = 0,
                 bool generateAsimovDataForObserved = false,
                 int nCPUs = 1
@@ -58,10 +58,10 @@ namespace RooStats
                 bool doUL = true, // true = exclusion, false = discovery
                 int ntoys=1000,
                 int calculatorType = 0,
-                int testStatType = 3, 
+                int testStatType = 3,
                 const char * modelSBName = "ModelConfig",
                 const char * modelBName = "",
-                const char * dataName = "obsData",                 
+                const char * dataName = "obsData",
                 bool useNumberCounting = false,
                 const char * nuisPriorName = 0) ;
 
@@ -101,31 +101,31 @@ namespace RooStats
                 bool useNumberCounting = false,
                 const char * nuisPriorName = 0) ;
 
-    void AnalyzeHypoTestInverterResult(const char* infile, 
+    void AnalyzeHypoTestInverterResult(const char* infile,
             const char* resultName,
             int calculatorType,
-            int testStatType , 
-            bool useCLs ,  
+            int testStatType ,
+            bool useCLs ,
             int npoints,
             const char* outfilePrefix = "",
             const char* plotType = ".pdf"
             ) ;
 
-    void AnalyzeHypoTestInverterResult(RooStats::HypoTestInverterResult* result, 
+    void AnalyzeHypoTestInverterResult(RooStats::HypoTestInverterResult* result,
             int calculatorType,
-            int testStatType , 
-            bool useCLs ,  
+            int testStatType ,
+            bool useCLs ,
             int npoints,
             const char* outfilePrefix = "",
             const char* plotType = ".pdf"
             ) ;
 
-    RooStats::HypoTestInverterResult* MakeUpperLimitPlot(const char* fileprefix, 
+    RooStats::HypoTestInverterResult* MakeUpperLimitPlot(const char* fileprefix,
                 RooWorkspace* w,
                 int calculatorType = 0,
-                int testStatType = 3, 
+                int testStatType = 3,
                 int ntoys=1000,
-                bool useCLs = true ,  
+                bool useCLs = true ,
                 int npoints = 20 ) ;
 
     LimitResult get_Pvalue( const RooStats::HypoTestInverterResult* fResults, bool doUL=true );

--- a/src/TEasyFormula.h
+++ b/src/TEasyFormula.h
@@ -16,8 +16,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef __TEasyFormula__
-#define __TEasyFormula__
+#ifndef TEASYFORMULA_H
+#define TEASYFORMULA_H
 
 #include <vector>
 #include <map>
@@ -30,7 +30,7 @@ class TEasyFormula : public ROOT::v5::TFormula {
 
     public:
 
-        TEasyFormula();      
+        TEasyFormula();
         TEasyFormula(const char* expression);
         TEasyFormula(const char* name, const char* expression);
         virtual ~TEasyFormula();
@@ -48,7 +48,7 @@ class TEasyFormula : public ROOT::v5::TFormula {
         Bool_t Contains(const TString& parname) const;
         Bool_t Contains(const std::vector<TString>& parList) const;
 
-        inline double GetDoubleValue()  { return this->EvalPar(0,0); } 
+        inline double GetDoubleValue()  { return this->EvalPar(0,0); }
         inline float  GetFloatValue()   { return static_cast<float>( this->EvalPar(0,0) ); }
         inline bool   GetBoolValue()    { return static_cast<bool>( this->EvalPar(0,0) ); }
         inline int    GetIntValue()     { return static_cast<int>( this->EvalPar(0,0) ); }

--- a/src/TMsgLogger.h
+++ b/src/TMsgLogger.h
@@ -1,6 +1,6 @@
 // vim: ts=4:sw=4
 /**********************************************************************************
- * Project: HistFitter - A ROOT-based package for statistical data analysis       *  
+ * Project: HistFitter - A ROOT-based package for statistical data analysis       *
  * Package: HistFitter                                                            *
  * Class  : TMsgLogger                                                            *
  *                                                                                *
@@ -27,8 +27,8 @@
  * (http://tmva.sourceforge.net/LICENSE)                                          *
  **********************************************************************************/
 
-#ifndef ROOT_TMsgLogger
-#define ROOT_TMsgLogger
+#ifndef TMSGLOGGER_H
+#define TMSGLOGGER_H
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
@@ -49,8 +49,8 @@
 #include "TString.h"
 #include "RooGlobalFunc.h"
 
-enum TMsgLevel { 
-    kVERBOSE = 1, 
+enum TMsgLevel {
+    kVERBOSE = 1,
     kDEBUG   = 2,
     kINFO    = 3,
     kWARNING = 4,
@@ -124,7 +124,7 @@ class TMsgLogger : public std::ostringstream, public TObject {
         }
 
         static void SetMinLevel( TMsgLevel minLevel, bool lock=false ) {
-            if(m_levelLock) 
+            if(m_levelLock)
                 return;
 
             m_minLevel = minLevel;
@@ -139,8 +139,8 @@ class TMsgLogger : public std::ostringstream, public TObject {
         std::map<TMsgLevel, std::string> GetLevelMap() const { return m_levelMap; }
 
         // for python
-        void writeLogMessage( TMsgLevel level, std::string message) { 
-            *(TMsgLogger*) this << level << message << TMsgLogger::endmsg; 
+        void writeLogMessage( TMsgLevel level, std::string message) {
+            *(TMsgLogger*) this << level << message << TMsgLogger::endmsg;
         }
 
     private:

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -16,7 +16,6 @@
  *                                                                                *
  * See corresponding .h file for author and license information                   *
  **********************************************************************************/
-
 #include <memory>
 
 #include "Utils.h"
@@ -54,7 +53,6 @@
 #include "RooMinimizer.h"
 #include "RooConstVar.h"
 #include "RooNumIntConfig.h"
-#include "RooMinuit.h"
 #include "RooFormulaVar.h"
 
 #include "RooStats/ModelConfig.h"
@@ -115,18 +113,18 @@ double Util::looseToTightVal(const TString& reg, TMap* map){
   double LtoTeffReal_W=((TObjString*)map->GetValue("LtoTeffReal_WZ_"+reg+"lmt"))->GetString().Atof();
   double fBTagTop=((TObjString*)map->GetValue("btag_sep_tt"))->GetString().Atof();
   double fBTagWZ=((TObjString*)map->GetValue("btag_sep_WZ"))->GetString().Atof();
-  
+
   double nTop=nTopTight * (LtoTeffReal_tt-1.0);
   double nWZ=nWTight * (LtoTeffReal_W-1.0);
-  if(reg=="TR"){ 
-    nTop=nTop*fBTagTop; 
-    nWZ=nWZ*fBTagWZ; 
+  if(reg=="TR"){
+    nTop=nTop*fBTagTop;
+    nWZ=nWZ*fBTagWZ;
   }
-  else if(reg=="WR"){ 
-    nTop=nTop*(1.0-fBTagTop); 
-    nWZ=nWZ*(1.0-fBTagWZ); 
+  else if(reg=="WR"){
+    nTop=nTop*(1.0-fBTagTop);
+    nWZ=nWZ*(1.0-fBTagWZ);
   }
-  
+
   double val=(nLMT-nTop-nWZ)/LtoTeffFake;
   return val;
 }
@@ -160,7 +158,7 @@ double Util::getNonQcdVal(const TString& proc, const TString& reg, TMap* map,con
 
 
 //_____________________________________________________________________________
-void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix, 
+void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
         Bool_t plotSeparateComponents, Bool_t plotNLL, Bool_t minos, TString minosPars,
         Bool_t doFixParameters, TString fixedPars, bool ReduceCorrMatrix, bool noFit, bool plotInterpolation ){
 
@@ -210,7 +208,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         return;
     }
 
-    Util::SetInterpolationCode(w,4); 
+    Util::SetInterpolationCode(w,4);
     if (not noFit ) {
         // only modify the workspace when actually fitting
         SaveInitialSnapshot(w);
@@ -232,7 +230,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
 
     //hack to be fixed at HistFactory level (check again with ROOT 5.34)
     // Bool_t lumiConst = kTRUE;
-    //if (fc->m_signalChannels.size() > 0) 
+    //if (fc->m_signalChannels.size() > 0)
     Bool_t lumiConst = kFALSE;
 
     //  fit toy MC if specified. When left None, data is fit by default
@@ -267,7 +265,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         ImportInWorkspace(w, expResultBefore, "RooExpandedFitResult_beforeFit");
     } else {
         // retrieve from the workspace
-        expResultBefore = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_beforeFit") ); 
+        expResultBefore = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_beforeFit") );
         LoadSnapshotInWorkspace(w, "snapshot_paramsVals_RooExpandedFitResult_beforeFit");
     }
 
@@ -283,9 +281,9 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         h.setOutputPrefix("beforeFit");
         h.setFitResult(expResultBefore);
         h.setInputData(toyMC);
-        
+
         h.Initialize();
-        h.PlotRegions(); 
+        h.PlotRegions();
         //h.saveHistograms();
     }
 
@@ -297,7 +295,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         result = FitPdf(w, fitChannels, lumiConst, toyMC, "", minos, minosPars, doFixParameters, fixedPars);
 
         if (result == NULL) {
-            Logger << kERROR << "PlotNLL(): running FitPdf() failed!" << GEndl;    
+            Logger << kERROR << "PlotNLL(): running FitPdf() failed!" << GEndl;
             return;
         }
 
@@ -307,7 +305,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         ImportInWorkspace(w, expResultAfter, "RooExpandedFitResult_afterFit");
     } else {
         // load back the fit result
-        expResultAfter = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_afterFit") ); 
+        expResultAfter = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_afterFit") );
         LoadSnapshotInWorkspace(w, "snapshot_paramsVals_RooExpandedFitResult_afterFit");
     }
 
@@ -321,19 +319,19 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         h.setOutputPrefix("afterFit");
         h.setFitResult(expResultAfter);
         h.setInputData(toyMC);
-        
+
         // plot each component of each region separately with propagated
         // error after fit  (interesting for debugging)
-        if(plotSeparateComponents) { 
-            h.setPlotSeparateComponents(true); 
+        if(plotSeparateComponents) {
+            h.setPlotSeparateComponents(true);
         }
-        
+
         h.Initialize();
-        h.PlotRegions(); 
+        h.PlotRegions();
     }
 
     //plot correlation matrix for result
-    if(plotCorrelationMatrix) { 
+    if(plotCorrelationMatrix) {
         //PlotCorrelationMatrix(result, anaName, ReduceCorrMatrix);
         PlotCorrelationMatrix(expResultAfter, anaName, ReduceCorrMatrix);
     }
@@ -343,16 +341,16 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
     if(plotNLL) {
         PlotNLL(w, expResultAfter, plotPLL, anaName, "", toyMC, minosPars, fitChannels, lumiConst);
     }
-    
+
     if(not noFit) {
         // only write out output workspace if we've run a fit
-        if (toyMC) { 
+        if (toyMC) {
             WriteWorkspace(w, inputFilename, toyMC->GetName());
         } else {
             WriteWorkspace(w, inputFilename);
         }
     }
-    if (result){  
+    if (result){
         result->Print("v");
         PlotFitParameters(result,anaName);
     }
@@ -368,7 +366,7 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
 ///////////////
 
 //_____________________________________________________________________________
-void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix, 
+void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
         Bool_t plotSeparateComponents, Bool_t plotNLL, Bool_t minos, TString minosPars,
         Bool_t doFixParameters, TString fixedPars, bool ReduceCorrMatrix){
 
@@ -415,7 +413,7 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
         return;
     }
 
-    Util::SetInterpolationCode(w,4); 
+    Util::SetInterpolationCode(w,4);
     if (not noFit ) {
         // only modify the workspace when actually fitting
         SaveInitialSnapshot(w);
@@ -437,7 +435,7 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
 
     //hack to be fixed at HistFactory level (check again with ROOT 5.34)
     // Bool_t lumiConst = kTRUE;
-    //if (fc->m_signalChannels.size() > 0) 
+    //if (fc->m_signalChannels.size() > 0)
     Bool_t lumiConst = kFALSE;
 
     //  fit toy MC if specified. When left None, data is fit by default
@@ -472,11 +470,11 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
         ImportInWorkspace(w, expResultBefore, "RooExpandedFitResult_beforeFit");
     } else {
         // retrieve from the workspace
-        expResultBefore = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_beforeFit") ); 
+        expResultBefore = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_beforeFit") );
         LoadSnapshotInWorkspace(w, "snapshot_paramsVals_RooExpandedFitResult_beforeFit");
     }
 
-    // plot before fit  
+    // plot before fit
     if (drawBeforeFit)
         PlotPdfWithComponents(w, "beforeFit", anaName, plotChannels, "beforeFit", expResultBefore, toyMC);
 
@@ -487,7 +485,7 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
         //result = FitPdf(w, fitChannels, lumiConst, toyMC, "", minos, minosPars, doFixParameters, fixedPars);
 
         //if (result == NULL) {
-            //Logger << kERROR << "PlotNLL(): running FitPdf() failed!" << GEndl;    
+            //Logger << kERROR << "PlotNLL(): running FitPdf() failed!" << GEndl;
             //return;
         //}
 
@@ -497,7 +495,7 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
         //ImportInWorkspace(w, expResultAfter, "RooExpandedFitResult_afterFit");
     //} else {
         // load back the fit result
-        expResultAfter = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_afterFit") ); 
+        expResultAfter = static_cast<RooExpandedFitResult*>( w->genobj("RooExpandedFitResult_afterFit") );
         LoadSnapshotInWorkspace(w, "snapshot_paramsVals_RooExpandedFitResult_afterFit");
     //}
 
@@ -508,13 +506,13 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
 
     // plot each component of each region separately with propagated
     // error after fit  (interesting for debugging)
-    if(plotSeparateComponents) { 
+    if(plotSeparateComponents) {
         //PlotSeparateComponents(w, fc->m_name, anaName, plotChannels, "afterFit", result, toyMC);
         PlotSeparateComponents(w, "afterFit_separateComponents", anaName, plotChannels, "afterFit", expResultAfter, toyMC);
     }
 
     //plot correlation matrix for result
-    if(plotCorrelationMatrix) { 
+    if(plotCorrelationMatrix) {
         //PlotCorrelationMatrix(result, anaName, ReduceCorrMatrix);
         PlotCorrelationMatrix(expResultAfter, anaName, ReduceCorrMatrix);
     }
@@ -525,16 +523,16 @@ void Util::GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit
         //PlotNLL(w, expResultAfter, plotPLL, anaName, "", toyMC, minosPars, fitChannels, lumiConst);
         PlotNLL(w, expResultAfter, plotPLL, anaName, "", toyMC, minosPars, "ALL", lumiConst);
     }
-    
+
     if(not noFit) {
         // only write out output workspace if we've run a fit
-        if (toyMC) { 
+        if (toyMC) {
             WriteWorkspace(w, inputFilename, toyMC->GetName());
         } else {
             WriteWorkspace(w, inputFilename);
         }
     }
-    if (result)  
+    if (result)
         result->Print("v");
 }
 
@@ -559,7 +557,7 @@ void Util::SaveInitialSnapshot(RooWorkspace* w){
         Logger << kWARNING << "Util::SaveInitialSnapshot():   not saving the initial snapshot as cannot find pdf (simPdf or combPdf) in workspace" << GEndl;
         return;
     }
-      
+
     RooAbsData* data = (RooAbsData*) w->data("obsData");
     RooArgSet* params = (RooArgSet*) pdf->getParameters(*data) ;
     if(!w->loadSnapshot("snapshot_paramsVals_initial")) {
@@ -579,14 +577,14 @@ void Util::LoadSnapshotInWorkspace(RooWorkspace* w,TString snapshot){
 
     Bool_t loaded =  w->loadSnapshot(snapshot);
 
-    if (loaded){ 
-        Logger << kINFO << "workspace loaded" << GEndl; 
-        return; 
-    } else { 
+    if (loaded){
+        Logger << kINFO << "workspace loaded" << GEndl;
+        return;
+    } else {
         Logger << kWARNING << "Util.LoadSnapshotInWorkspace() did not find snapshot named "  << snapshot << ", check your workspace file" << GEndl;
     }
 
-    return;  
+    return;
 
 }
 
@@ -594,9 +592,9 @@ void Util::LoadSnapshotInWorkspace(RooWorkspace* w,TString snapshot){
 //_____________________________________________________________________________
 void Util::WriteWorkspace(RooWorkspace* w, TString outFileName, TString suffix){
 
-    if(w==NULL){ 
-        Logger << kERROR << "Workspace not found, not writing workspace to file" << GEndl; 
-        return; 
+    if(w==NULL){
+        Logger << kERROR << "Workspace not found, not writing workspace to file" << GEndl;
+        return;
     }
 
     outFileName.ReplaceAll(".root","_afterFit.root");
@@ -618,7 +616,7 @@ void Util::WriteWorkspace(RooWorkspace* w, TString outFileName, TString suffix){
 
 
 /*
- * The FitPdf() function is (partially) taken from the function 
+ * The FitPdf() function is (partially) taken from the function
  * RooStats::ProfileLikelihoodTestStat::GetMinNLL()
  * See: http://root.cern.ch/root/html534/src/RooStats__ProfileLikelihoodTestStat.cxx.html
  * ((http://root.cern.ch/drupal/content/license))
@@ -636,9 +634,9 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
 
     RooMsgService::instance().getStream(1).removeTopic(NumIntegration);
 
-    if(!w){ 
+    if(!w){
         Logger << kERROR << "Workspace not found, no fitting performed" << GEndl;
-        return NULL; 
+        return NULL;
     }
 
     if(!deactivateBinnedLikelihood) {
@@ -654,24 +652,24 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
 
     RooSimultaneous* pdf = static_cast<RooSimultaneous*>(w->pdf("simPdf"));
 
-    RooAbsData* data = ( inputData!=0 ? inputData : static_cast<RooAbsData*>(w->data("obsData")) ); 
+    RooAbsData* data = ( inputData!=0 ? inputData : static_cast<RooAbsData*>(w->data("obsData")) );
     if(!data) {
         Logger << kFATAL << "Can't find RooAbsData 'data' in workspace. Are you attempting to run a blinded fit but did you not add a (dummy) data sample?" << GEndl;
-        return NULL; 
+        return NULL;
     }
-    
-    RooCategory* regionCat = (RooCategory*) w->cat("channelCat");  
+
+    RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
     if(!regionCat) {
         Logger << kERROR << "Can't find RooCategory 'channelCat' in workspace" << GEndl;
-        return NULL; 
+        return NULL;
     }
-   
+
     RooAbsCategory* absRegionCat = static_cast<RooAbsCategory*>(regionCat);
     if(!absRegionCat) {
         Logger << kERROR << "Can't cast RooAbsCategory 'channelCat' from workspace" << GEndl;
-        return NULL; 
+        return NULL;
     }
-  
+
     Logger << kINFO << "Will dump channelCat as RooAbsCategory now:" << GEndl;
     absRegionCat->Print("v");
 
@@ -687,15 +685,15 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
 
     if (lumiConst) {
         RooRealVar* lumi = (RooRealVar*) w->var("Lumi");
-        if (lumi!=NULL) lumi->setConstant(lumiConst); 
+        if (lumi!=NULL) lumi->setConstant(lumiConst);
     }
-    
+
     //fixing parameters to certain values
     if (doFixParameters && fixedPars != "") {
      std::vector<TString> fixedParsVector = Tokens(fixedPars,",");
      for (unsigned int j=0; j<fixedParsVector.size(); j++) {
          std::vector<TString> fixedParsPair = Tokens(fixedParsVector[j],":");
-         if (fixedParsPair.size() != 2) { 
+         if (fixedParsPair.size() != 2) {
              Logger << kERROR << " Util::FitPdf() fixing parameters to constant: wrong arguments given: " <<  fixedParsVector[j] << GEndl;
              Logger << kERROR << " Util::FitPdf() Ignore this and continue." << GEndl;
              continue;
@@ -707,7 +705,7 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
              var->setVal(fixedParsPair[1].Atof());
              var->setConstant(kTRUE);
          }
-     }        
+     }
     }
 
     // Construct an empty simultaneous pdf using category regionCat as index
@@ -722,8 +720,8 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
 
     for(unsigned int iVec=0; iVec<numFitRegions; iVec++){
         TString regionCatLabel = fitRegionsVec[iVec];
-        if( regionCat->setLabel(regionCatLabel,kTRUE)){  
-            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl; 
+        if( regionCat->setLabel(regionCatLabel,kTRUE)){
+            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl;
         } else{
             // dataset for each channel/region/category
             TString dataCatLabel = Form("channelCat==channelCat::%s",regionCatLabel.Data());
@@ -736,12 +734,12 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
     }
 
 
-    if(dataVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl; 
+    if(dataVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl;
         return 0;
     }
-    else if(pdfVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl; 
+    else if(pdfVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl;
         return 0;
     }
     else{
@@ -788,7 +786,7 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
     RooStats::ModelConfig* mc = Util::GetModelConfig( w );
     const RooArgSet* globObs = mc->GetGlobalObservables();
 
-    RooAbsReal* nll = (RooNLLVar*) pdf_FR->createNLL(*data_FR, RooFit::GlobalObservables(*globObs), RooFit::Offset(true) ); 
+    RooAbsReal* nll = (RooNLLVar*) pdf_FR->createNLL(*data_FR, RooFit::GlobalObservables(*globObs), RooFit::Offset(true) );
 
     int minimPrintLevel = 1; //verbose;
 
@@ -801,34 +799,34 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
     double tol =  ROOT::Math::MinimizerOptions::DefaultTolerance();
     tol = std::max(tol, 1.0); // 1.0 is the minimum value used in RooMinimizer
     minim.setEps( tol );
-    
+
     //LM: RooMinimizer.setPrintLevel has +1 offset - so subtruct  here -1
     minim.setPrintLevel(minimPrintLevel-1);
     int status = -1;
     minim.optimizeConst(2);
-    TString minimizer = "Minuit2"; //ROOT::Math::MinimizerOptions::DefaultMinimizerType(); 
-    TString algorithm = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo(); 
+    TString minimizer = "Minuit2"; //ROOT::Math::MinimizerOptions::DefaultMinimizerType();
+    TString algorithm = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
 
-    Logger << kINFO << "Util::FitPdf()  ........ using " << minimizer << " / " << algorithm << GEndl; 
+    Logger << kINFO << "Util::FitPdf()  ........ using " << minimizer << " / " << algorithm << GEndl;
     Logger << kINFO << " with strategy  " << strategy << " and tolerance " << tol << GEndl;
 
 
     for (int tries = 1, maxtries = 4; tries <= maxtries; ++tries) {
-        status = minim.minimize(minimizer, algorithm);  
-        if (status%1000 == 0) {  // ignore erros from Improve 
+        status = minim.minimize(minimizer, algorithm);
+        if (status%1000 == 0) {  // ignore erros from Improve
             break;
-        } else { 
+        } else {
             if (tries == 1) {
                 Logger << kINFO << "    ----> Doing a re-scan first" << GEndl;
                 minim.minimize(minimizer,"Scan");
             }
             if (tries == 2) {
-                if (ROOT::Math::MinimizerOptions::DefaultStrategy() == 0 ) { 
+                if (ROOT::Math::MinimizerOptions::DefaultStrategy() == 0 ) {
                     Logger << kINFO << "    ----> trying with strategy = 1" << GEndl;
                     minim.setStrategy(1);
                 }
-                else 
-                    tries++; // skip this trial if stratehy is already 1 
+                else
+                    tries++; // skip this trial if stratehy is already 1
             }
             if (tries == 3) {
                 Logger << kINFO << "    ----> trying with improve" << GEndl;
@@ -852,10 +850,10 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
             minim.hesse();
         }
 
-        // save fit result 
+        // save fit result
         r = minim.save();
     }
-    else { 
+    else {
         Logger << kERROR << "FIT FAILED !- return a NaN NLL " << GEndl;
     }
 
@@ -884,7 +882,7 @@ RooFitResult* Util::FitPdf( RooWorkspace* w, TString fitRegions, Bool_t lumiCons
 
 
 //_____________________________________________________________________________
-void 
+void
 Util::SetInterpolationCode(RooWorkspace* w, Int_t code)
 {
     if(w==NULL){
@@ -895,9 +893,9 @@ Util::SetInterpolationCode(RooWorkspace* w, Int_t code)
     RooArgSet funcs = w->allFunctions();
     TIterator* iter = funcs.createIterator() ;
 
-    RooAbsArg* parg(0);  
+    RooAbsArg* parg(0);
     while((parg=(RooAbsArg*)iter->Next())) {
-        if ( parg->ClassName()!=TString("PiecewiseInterpolation") ) { continue; }    
+        if ( parg->ClassName()!=TString("PiecewiseInterpolation") ) { continue; }
         PiecewiseInterpolation* p = (PiecewiseInterpolation*)w->function( parg->GetName() ); // something I can modifiy :)
         p->setAllInterpCodes(code);
     }
@@ -907,22 +905,22 @@ Util::SetInterpolationCode(RooWorkspace* w, Int_t code)
 
 
 //_____________________________________________________________________________
-RooAbsData* 
+RooAbsData*
 Util::GetAsimovSet( RooWorkspace* inputws  )
 {
     RooWorkspace* w(0);
     if (inputws!=NULL) { w = inputws; }
     else { w = (RooWorkspace*) gDirectory->Get("w"); }
 
-    if(w==NULL){ 
-        Logger << kERROR << "Workspace not found, no Asimov set found. Return." << GEndl; 
-        return 0; 
+    if(w==NULL){
+        Logger << kERROR << "Workspace not found, no Asimov set found. Return." << GEndl;
+        return 0;
     }
 
     RooAbsData* data = w->data("asimovData");
-    if (data==NULL) { 
-        Logger << kERROR << "No Asimov set found. Return." << GEndl; 
-        return 0; 
+    if (data==NULL) {
+        Logger << kERROR << "No Asimov set found. Return." << GEndl;
+        return 0;
     }
 
     return data;
@@ -930,39 +928,39 @@ Util::GetAsimovSet( RooWorkspace* inputws  )
 
 
 //_____________________________________________________________________________
-    RooAbsData* 
+    RooAbsData*
 Util::GetToyMC( RooWorkspace* inputws  )
 {
     RooWorkspace* w(0);
     if (inputws!=NULL) { w = inputws; }
     else { w = (RooWorkspace*) gDirectory->Get("w"); }
-    if(w==NULL){ 
-        Logger << kERROR << "Workspace not found, no toy dataset generated." << GEndl; 
-        return 0; 
+    if(w==NULL){
+        Logger << kERROR << "Workspace not found, no toy dataset generated." << GEndl;
+        return 0;
     }
 
     RooStats::ModelConfig* mc = Util::GetModelConfig( w );
-    if (mc==NULL) { 
-        Logger << kERROR << "No model config found. Return." << GEndl; 
-        return 0; 
+    if (mc==NULL) {
+        Logger << kERROR << "No model config found. Return." << GEndl;
+        return 0;
     }
 
     RooAbsPdf* pdf = mc->GetPdf();
-    if (pdf==NULL) { 
-        Logger << kERROR << "No pdf found. Return." << GEndl; 
-        return 0; 
+    if (pdf==NULL) {
+        Logger << kERROR << "No pdf found. Return." << GEndl;
+        return 0;
     }
 
     RooAbsData* data = w->data("obsData");
-    if (data==NULL) { 
-        Logger << kERROR << "No dataset found. Return." << GEndl; 
-        return 0; 
+    if (data==NULL) {
+        Logger << kERROR << "No dataset found. Return." << GEndl;
+        return 0;
     }
 
     const RooArgSet* obsSet = mc->GetObservables();
-    if (obsSet==NULL) { 
-        Logger << kERROR << "No observables found. Return." << GEndl; 
-        return 0; 
+    if (obsSet==NULL) {
+        Logger << kERROR << "No observables found. Return." << GEndl;
+        return 0;
     }
 
     Logger << kINFO << "Util::GetToyMC() : now generating toy MC set with # events : " << data->sumEntries() << GEndl;
@@ -979,14 +977,14 @@ vector<TString> Util::GetRegionsVec(TString regions, RooCategory* regionCat){
     std::vector<TString> regionsAllVec = TokensALL(regionCat);
     std::vector<TString> regionsRequestedVec = Tokens(regions,",");
 
-    if(regions=="ALL"){ regionsVec = regionsAllVec; 
+    if(regions=="ALL"){ regionsVec = regionsAllVec;
     } else {
         for(unsigned int iReg=0; iReg<regionsAllVec.size(); iReg++){
             for(unsigned int jReg=0; jReg<regionsRequestedVec.size(); jReg++){
                 if( regionsAllVec[iReg].EqualTo(regionsRequestedVec[jReg]) ) {
                     regionsVec.push_back(regionsAllVec[iReg]);
                 }
-            }    
+            }
         }
     }
 
@@ -1008,7 +1006,7 @@ void Util::DecomposeWS(const char* infile, const char* wsname, const char* outfi
     }
 
     // open file and check if input file exists
-    TFile * file = TFile::Open(fileName); 
+    TFile * file = TFile::Open(fileName);
 
     // if input file was specified but not found, quit
     if(!file && !TString(infile).IsNull()){
@@ -1046,12 +1044,12 @@ void Util::DecomposeWS(const char* infile, const char* wsname, const char* outfi
 
     TString allObs;
 
-    // iterate over all the regions 
+    // iterate over all the regions
     for(unsigned int iVec=0; iVec<numPlots; iVec++){
 
         TString regionCatLabel = regionsVec[iVec];
-        if( regionCat->setLabel(regionCatLabel,kTRUE)){  
-            Logger << kINFO << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl; 
+        if( regionCat->setLabel(regionCatLabel,kTRUE)){
+            Logger << kINFO << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl;
         }else{
             RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionCatLabel.Data());
 
@@ -1059,7 +1057,7 @@ void Util::DecomposeWS(const char* infile, const char* wsname, const char* outfi
             RooDataSet* regionData = (RooDataSet*) data->reduce(dataCatLabel.Data());
             if(regionPdf==NULL || regionData==NULL){
                 Logger << kWARNING << " Either the Pdf or the Dataset do not have an appropriate state for the region = " << regionCatLabel << ", check the Workspace file" << GEndl;
-                Logger << kWARNING << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
+                Logger << kWARNING << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
                 continue;
             }
 
@@ -1091,31 +1089,31 @@ void Util::PlotPdfWithComponents(RooWorkspace* w, TString fcName, TString anaNam
     h.setPlotSeparateComponents(true); //TODO: hack
 
     h.Initialize();
-    h.PlotRegions(); 
+    h.PlotRegions();
 }
 
 //_____________________________________________________________________________________________________________________________________
 void Util::PlotSeparateComponents(RooWorkspace* w,TString fcName, TString anaName, TString plotRegions,TString outputPrefix, RooFitResult* rFit, RooAbsData* inputData)
 {
-    if(rFit==NULL){ 
-        Logger << kWARNING << " Running PlotSeparateComponents() without a RooFitResult is pointless, I'm done" << GEndl ; 
-        return; 
+    if(rFit==NULL){
+        Logger << kWARNING << " Running PlotSeparateComponents() without a RooFitResult is pointless, I'm done" << GEndl ;
+        return;
     }
 
     Bool_t plotComponents=true;
     ConfigMgr* mgr = ConfigMgr::getInstance();
     FitConfig* fc = mgr->getFitConfig(fcName);
 
-    Logger << kINFO << " ------ Starting PlotSeparateComponents with parameters:   analysisName = " << fcName << GEndl; 
+    Logger << kINFO << " ------ Starting PlotSeparateComponents with parameters:   analysisName = " << fcName << GEndl;
     Logger << kINFO << "    fitRegions = " <<  plotRegions <<  "  plotComponents = " << plotComponents << "  outputPrefix = " << outputPrefix  << GEndl;
 
-    if(w==NULL){ 
-        Logger << kWARNING << " Workspace not found, no plotting performed" << GEndl; 
-        return; 
+    if(w==NULL){
+        Logger << kWARNING << " Workspace not found, no plotting performed" << GEndl;
+        return;
     }
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
 
-    RooAbsData* data = ( inputData!=0 ? inputData : (RooAbsData*)w->data("obsData") ); 
+    RooAbsData* data = ( inputData!=0 ? inputData : (RooAbsData*)w->data("obsData") );
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
     data->table(*((RooAbsCategory*)regionCat))->Print("v");
 
@@ -1125,24 +1123,24 @@ void Util::PlotSeparateComponents(RooWorkspace* w,TString fcName, TString anaNam
     unsigned  int numRegions = regionsVec.size();
     TCanvas* canVec[numRegions];
 
-    for(unsigned int iVec=0; iVec<numRegions; iVec++){   
+    for(unsigned int iVec=0; iVec<numRegions; iVec++){
 
         TString regionCatLabel = regionsVec[iVec];
-        if( regionCat->setLabel(regionCatLabel,kTRUE)){  
+        if( regionCat->setLabel(regionCatLabel,kTRUE)){
             Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl;
         } else{
             RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionCatLabel.Data());
             TString dataCatLabel = Form("channelCat==channelCat::%s",regionCatLabel.Data());
             RooAbsData* regionData = (RooAbsData*) data->reduce(dataCatLabel.Data());
             ChannelStyle style = fc->getChannelStyle(regionCatLabel);
-            if(regionPdf==NULL || regionData==NULL){ 
+            if(regionPdf==NULL || regionData==NULL){
                 Logger << kERROR << " Either the Pdf or the Dataset do not have an appropriate state for the region = " << regionCatLabel << ", check the Workspace file" << GEndl;
-                Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
-                continue; 
+                Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
+                continue;
             }
             RooRealVar* regionVar =(RooRealVar*) ((RooArgSet*) regionPdf->getObservables(*regionData))->find(Form("obs_x_%s",regionCatLabel.Data()));
             // get all components/samples in this region
-            TString RRSPdfName = Form("%s_model",regionCatLabel.Data()); 
+            TString RRSPdfName = Form("%s_model",regionCatLabel.Data());
             RooRealSumPdf* RRSPdf = (RooRealSumPdf*) regionPdf->getComponents()->find(RRSPdfName);
             TString binWidthName =  Form("binWidth_obs_x_%s_0",regionCatLabel.Data());
             RooRealVar* regionBinWidth = ((RooRealVar*) RRSPdf->getVariables()->find(Form("binWidth_obs_x_%s_0",regionCatLabel.Data()))) ;
@@ -1161,20 +1159,20 @@ void Util::PlotSeparateComponents(RooWorkspace* w,TString fcName, TString anaNam
                 canVecDivX = ((Int_t) (sqrt(numComps)));
                 canVecDivY = ((Int_t) (sqrt(numComps)+0.5));
 
-                if(canVecDivX<1) 
+                if(canVecDivX<1)
                     canVecDivX = 1;
-                if(canVecDivY<1) 
+                if(canVecDivY<1)
                     canVecDivY = 1;
-            }  
+            }
 
             TString canName=Form("can_%s_%s_separateComponents",regionCatLabel.Data(),outputPrefix.Data());
-            canVec[iVec] = new TCanvas(canName,canName,600,600); // .c_str()) 
+            canVec[iVec] = new TCanvas(canName,canName,600,600); // .c_str())
             canVec[iVec]->Divide(canVecDivX , canVecDivY);
 
             //iterate over all samples and plot
             for( unsigned int iComp=0; iComp<regionCompFracVec.size(); iComp++){
                 TString component =  regionCompNameVec[iComp];
-                RooPlot* frame =  regionVar->frame(); 
+                RooPlot* frame =  regionVar->frame();
                 frame->SetName(Form("frame_%s_%s_%s",regionCatLabel.Data(),regionCompNameVec[iComp].Data(),outputPrefix.Data()));
                 Int_t  compPlotColor = ( (fc!=0) ? style.getSampleColor(regionCompNameVec[iComp]) : static_cast<int>(iComp) );
                 TString  compShortName  = ( (fc!=0) ? style.getSampleName(regionCompNameVec[iComp])  : "" );
@@ -1182,9 +1180,9 @@ void Util::PlotSeparateComponents(RooWorkspace* w,TString fcName, TString anaNam
                 // normalize pdf to number of expected events, not to number of events in dataset
                 double normCount = regionPdf->expectedEvents(*regionVar);
 
-                if (rFit != NULL) 
+                if (rFit != NULL)
                     regionPdf->plotOn(frame,Components(regionCompNameVec[iComp].Data()),VisualizeError(*rFit),FillColor(kCyan),Precision(1e-5),Normalization(1,RooAbsReal::RelativeExpected));
-    
+
                 regionPdf->plotOn(frame,Components(regionCompNameVec[iComp].Data()),LineColor(compPlotColor),Normalization(regionCompFracVec[iComp]*normCount,RooAbsReal::NumEvent),Precision(1e-5));
 
                 canVec[iVec]->cd(iComp+1);
@@ -1216,19 +1214,19 @@ void Util::PlotSeparateComponents(RooWorkspace* w,TString fcName, TString anaNam
 //_____________________________________________________________________________________________________________________________________
 void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString anaName, TString outputPrefix, RooAbsData* inputData, TString plotPars, TString fitRegions, Bool_t lumiConst)
 {
-    if(rFit==NULL){ 
-        Logger << kWARNING << " Running PlotNLL() without a RooFitResult is pointless, I'm done" << GEndl ; 
-        return; 
+    if(rFit==NULL){
+        Logger << kWARNING << " Running PlotNLL() without a RooFitResult is pointless, I'm done" << GEndl ;
+        return;
     }
 
     Logger << kINFO << " ------ Starting PlotNLL with parameters: " << GEndl;
     Logger << kINFO << "  outputPrefix = " << outputPrefix  << GEndl;
 
-    if(!w){ 
-        Logger << kINFO << " Workspace not found, no plotting performed" << GEndl; 
-        return; 
+    if(!w){
+        Logger << kINFO << " Workspace not found, no plotting performed" << GEndl;
+        return;
     }
-    
+
     if(!deactivateBinnedLikelihood) {
         RooFIter iter = w->components().fwdIterator();
         RooAbsArg* arg;
@@ -1243,13 +1241,13 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
 
-    RooAbsData* data = ( inputData!=0 ? inputData : (RooAbsData*)w->data("obsData") ); 
+    RooAbsData* data = ( inputData!=0 ? inputData : (RooAbsData*)w->data("obsData") );
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
     data->table(*((RooAbsCategory*)regionCat))->Print("v");
 
     if (lumiConst) {
         RooRealVar* lumi = (RooRealVar*) w->var("Lumi");
-        if (lumi!=NULL) lumi->setConstant(lumiConst); 
+        if (lumi!=NULL) lumi->setConstant(lumiConst);
     }
 
     // Construct an empty simultaneous pdf using category regionCat as index
@@ -1264,8 +1262,8 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 
     for(unsigned int iVec=0; iVec<numFitRegions; iVec++){
         TString regionCatLabel = fitRegionsVec[iVec];
-        if( regionCat->setLabel(regionCatLabel,kTRUE)){  
-            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl; 
+        if( regionCat->setLabel(regionCatLabel,kTRUE)){
+            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl;
         } else{
             // dataset for each channel/region/category
             TString dataCatLabel = Form("channelCat==channelCat::%s",regionCatLabel.Data());
@@ -1277,12 +1275,12 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
         }
     }
 
-    if(dataVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl; 
+    if(dataVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl;
         return;
     }
-    else if(pdfVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl; 
+    else if(pdfVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl;
         return;
     }
     else{
@@ -1318,7 +1316,7 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
     RooStats::ModelConfig* mc = Util::GetModelConfig( w );
     const RooArgSet* globObs = mc->GetGlobalObservables();
 
-    // Create Log Likelihood    
+    // Create Log Likelihood
     RooAbsReal* nll = simPdfFitRegions->createNLL(*dataFitRegions,NumCPU(2), RooFit::GlobalObservables(*globObs), RooFit::Offset(true)) ;
 
     unsigned int numParsP = plotParams->getSize();
@@ -1373,23 +1371,23 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 
         Double_t curveMax = curve->getYAxisMax();
         // safety for weird RooPlots where curve goes to infinity in first/last bin(s)
-        if (curveMax > 0. && !std::isinf(curveMax) && !std::isnan(curveMax) )  { ; } // frame->SetMaximum(curveMax * 2.); 
+        if (curveMax > 0. && !std::isinf(curveMax) && !std::isnan(curveMax) )  { ; } // frame->SetMaximum(curveMax * 2.);
         else if(curveMax > 0. && (std::isinf(curveMax) || std::isnan(curveMax))){
 
             for(Int_t iBin=1;  iBin < curve->GetN()-1; iBin++){
                 Double_t xBin = 0.;
-                Double_t yBin = -1.;     
+                Double_t yBin = -1.;
                 curve->GetPoint(iBin,xBin,yBin) ;
                 if(std::isinf(yBin)  || std::isnan(yBin)){
                     curve->RemovePoint(iBin);
                     Logger << kWARNING << " Removing bin = " << iBin  << " as it was either inf or nan from NLL plot for parameter = " << parName<< GEndl;
                     iBin--;
                 }
-            } 
+            }
 
             Int_t iBin = 1;
             Double_t xFirstBin = 0.;
-            Double_t yFirstBin = -1.; 
+            Double_t yFirstBin = -1.;
             while ( (yFirstBin<0 || std::isinf(yFirstBin)  || std::isnan(yFirstBin) )&& iBin < curve->GetN()-1){
                 iBin++;
                 curve->GetPoint(iBin,xFirstBin,yFirstBin) ;
@@ -1403,13 +1401,13 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
             Double_t yLastBin = -1.;
             while ( (yLastBin < 0 || std::isinf(yLastBin) || std::isnan(yLastBin) ) && iBin >0){
                 iBin--;
-                curve->GetPoint(iBin,xLastBin,yLastBin) ; 
+                curve->GetPoint(iBin,xLastBin,yLastBin) ;
                 if(std::isinf(yLastBin)  || std::isnan(yLastBin)){
                     curve->RemovePoint(iBin);
                     Logger << kWARNING << " Removing bin = " << iBin  << " as it was either inf or nan from NLL plot for parameter = " << parName<< GEndl;
                 }
             }
-            curveMax = yLastBin>yFirstBin ? yLastBin : yFirstBin;      
+            curveMax = yLastBin>yFirstBin ? yLastBin : yFirstBin;
         }
 
         // plot cosmetics
@@ -1429,7 +1427,7 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 
         RooAbsReal* pll(0);
         TGraph *pllCurve = 0;
-        if(plotPLL) { 
+        if(plotPLL) {
             pll = nll->createProfile(*par) ;
             pll->plotOn(frame, LineColor(kRed), LineStyle(kDashed), NumCPU(4));
             //const char* curvename = 0;
@@ -1441,9 +1439,9 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 
 
         TString canName=Form("can_NLL_%s_%s_%s", outputPrefix.Data(), rFit->GetName(), parName.Data());
-        canVec[iPar] = new TCanvas(canName, canName, 600, 600); 
+        canVec[iPar] = new TCanvas(canName, canName, 600, 600);
         canVec[iPar]->cd();
-        frame->Draw();  
+        frame->Draw();
 
         TLegend* leg = new TLegend(0.55, 0.65, 0.85, 0.9, "");
         leg->SetFillStyle(0);
@@ -1451,7 +1449,7 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
         leg->SetBorderSize(0);
         TLegendEntry* entry=leg->AddEntry("", "NLL", "l") ;
         entry->SetLineColor(kBlue);
-        if(plotPLL) {   
+        if(plotPLL) {
             entry=leg->AddEntry("", "PLL", "l") ;
             entry->SetLineColor(kRed);
             entry->SetLineStyle(kDashed);
@@ -1490,9 +1488,9 @@ void Util::PlotNLL(RooWorkspace* w, RooFitResult* rFit, Bool_t plotPLL, TString 
 TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool ReduceMatrix){
 
 
-    if(rFit==NULL){ 
-        Logger << kWARNING << "Running PlotCorrelationMatrix() without a RooFitResult is pointless, I'm done" << GEndl ; 
-        throw 1 ; 
+    if(rFit==NULL){
+        Logger << kWARNING << "Running PlotCorrelationMatrix() without a RooFitResult is pointless, I'm done" << GEndl ;
+        throw 1 ;
     }
 
     Logger << kINFO << " ------ Starting PlotCorrelationMatrix() " << GEndl;
@@ -1500,7 +1498,7 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
     Int_t numPars = rFit->floatParsFinal().getSize();
 
     TString canName = Form("c_corrMatrix_%s",rFit->GetName());
-    TCanvas* c_corr = new TCanvas(canName.Data(),canName.Data(),600,400); // .c_str()) 
+    TCanvas* c_corr = new TCanvas(canName.Data(),canName.Data(),600,400); // .c_str())
 
     Double_t orig_MarkerSize =  gStyle->GetMarkerSize();
     Int_t orig_MarkerColor =  gStyle->GetMarkerColor();
@@ -1518,7 +1516,7 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
     else if(numPars<40)    gStyle->SetMarkerSize(0.5);
     else     gStyle->SetMarkerSize(0.25);
 
-    TH2D* h_corr = (TH2D*) rFit->correlationHist(Form("h_corr_%s",rFit->GetName())); 
+    TH2D* h_corr = (TH2D*) rFit->correlationHist(Form("h_corr_%s",rFit->GetName()));
     int nbins = h_corr->GetNbinsX();
 
     for (int xbin=1; xbin<nbins+1; xbin++) {
@@ -1550,7 +1548,7 @@ TH2D* Util::PlotCorrelationMatrix(RooFitResult* rFit, TString anaName,  bool Red
     if (ReduceMatrix) {
       // Cleanup corrMattrix from rows and columns with content less then corrThres
       vector <int> rm_idx; rm_idx.clear();
-      double corrThresh[3] = {0.01,0.1,0.2}; 
+      double corrThresh[3] = {0.01,0.1,0.2};
       int index_x=0, index_y=0, Thresh1Counter;//, Thresh0Counter, Thresh2Counter;
       bool fillHistY, fillHistX;
 
@@ -1640,14 +1638,14 @@ TH2D* Util::GetCorrelations(RooFitResult* rFit, double threshold, TString anaNam
         for(unsigned int iBinX = 1; iBinX <= nBinsX && iBinX <= (nBinsX-iBinY); iBinX++){
             if(fabs(h_corr->GetBinContent(iBinX,iBinY)) > threshold){
                 Logger << kWARNING << " High correlation coefficient between:   par1 = " << h_corr->GetXaxis()->GetBinLabel(iBinX) << "  and par2 = "
-                    << h_corr->GetYaxis()->GetBinLabel(iBinY) << " " 
+                    << h_corr->GetYaxis()->GetBinLabel(iBinY) << " "
                     << " val = " << h_corr->GetBinContent(iBinX,iBinY) << GEndl;
             }
         }
     }
 
     return h_corr;
-} 
+}
 
 
 
@@ -1768,7 +1766,7 @@ RooStats::ModelConfig* Util::GetModelConfig( const RooWorkspace* w, const TStrin
 
 
 //________________________________________________________________________________________________
-    RooRealVar* 
+    RooRealVar*
 Util::GetPOI( const RooWorkspace* w  )
 {
     if(w==0){
@@ -1818,12 +1816,12 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
         return NULL;
     }
 
-    /// get pdf and dataset 
+    /// get pdf and dataset
     RooDataSet* data(0);
-    if (inputdata!=0) { 
+    if (inputdata!=0) {
         data = inputdata;
     }
-    else              
+    else
         data = dynamic_cast<RooDataSet*>(w->data("obsData")); // default: fit to data
     if (verbose) data->Print();
 
@@ -1837,9 +1835,9 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
     if (resetAfterFit) {
         // save snapshot before any fit has been done
         RooArgSet* params = (RooArgSet*) pdf->getParameters(*data) ;
-        if(!w->loadSnapshot("snapshot_paramsVals_initial")) { 
+        if(!w->loadSnapshot("snapshot_paramsVals_initial")) {
             w->saveSnapshot("snapshot_paramsVals_initial",*params);
-        } else { 
+        } else {
             Logger << kWARNING << "Snapshot 'snapshot_paramsVals_initial' already exists in  workspace, will not overwrite it" << GEndl;
         }
     }
@@ -1851,7 +1849,7 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
 
     const RooArgSet* globObs = mc->GetGlobalObservables();
 
-    RooAbsReal* nll = (RooNLLVar*) pdf->createNLL(*data, RooFit::GlobalObservables(*globObs), RooFit::Offset(true)); 
+    RooAbsReal* nll = (RooNLLVar*) pdf->createNLL(*data, RooFit::GlobalObservables(*globObs), RooFit::Offset(true));
 
     // find parameters requested for Minos
     RooArgSet* minosParams = new RooArgSet();
@@ -1872,33 +1870,33 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
     RooMinimizer minim(*nll);
     int strategy = ROOT::Math::MinimizerOptions::DefaultStrategy();
     minim.setStrategy( strategy);
-    
+
     // use tolerance - but never smaller than 1 (default in RooMinimizer)
     double tol =  ROOT::Math::MinimizerOptions::DefaultTolerance();
     tol = std::max(tol,1.0); // 1.0 is the minimum value used in RooMinimizer
     minim.setEps( tol );
-    
+
     //LM: RooMinimizer.setPrintLevel has +1 offset - so subtruct  here -1
     minim.setPrintLevel(minimPrintLevel-1);
     minim.optimizeConst(2);
-    
-    TString minimizer = "Minuit2"; //ROOT::Math::MinimizerOptions::DefaultMinimizerType(); 
-    TString algorithm = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo(); 
-    
+
+    TString minimizer = "Minuit2"; //ROOT::Math::MinimizerOptions::DefaultMinimizerType();
+    TString algorithm = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
+
     int status = -1;
 
     // require covQual = 3 from any fit while retrying?
     bool requireGoodCovQual = true;
 
-    Logger << kINFO << "Util::doFreeFit()  ........ using " << minimizer << " / " << algorithm 
+    Logger << kINFO << "Util::doFreeFit()  ........ using " << minimizer << " / " << algorithm
         << " with strategy  " << strategy << " and tolerance " << tol << GEndl;
 
     for (int tries = 1, maxtries = 5; tries <= maxtries; ++tries) {
         //   status = minim.minimize(fMinimizer, ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo().c_str());
-        status = minim.minimize(minimizer, algorithm); 
+        status = minim.minimize(minimizer, algorithm);
 
-        if (status%1000 == 0) {  // ignore erros from Improve 
-            
+        if (status%1000 == 0) {  // ignore erros from Improve
+
             // if desired, is the covariance matrix OK?
             std::unique_ptr<RooFitResult> res(minim.save());
             if(!requireGoodCovQual || res->covQual() == 3){
@@ -1906,8 +1904,8 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
             } else {
                 Logger << kINFO << " status OK but covariance matrix not at full accuracy, retrying" << GEndl;
             }
-        } 
-            
+        }
+
         if (tries == 1) {
             Logger << kINFO << "    ----> Doing a re-scan first" << GEndl;
             minim.minimize(minimizer,"Scan");
@@ -1916,16 +1914,16 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
                 Logger << kINFO << "    ----> trying with strategy = 1" << GEndl;
                 strategy = 1;
                 minim.setStrategy(strategy);
-            } else { 
-                tries++; // skip this trial if stratehy is already 1 
+            } else {
+                tries++; // skip this trial if stratehy is already 1
             }
         } else if (tries == 3) {
             if (strategy == 1) {
                 Logger << kINFO << "    ----> trying with strategy = 2" << GEndl;
                 strategy = 2;
                 minim.setStrategy(strategy);
-            } else { 
-                tries++; // skip this trial if stratehy is already 2 
+            } else {
+                tries++; // skip this trial if stratehy is already 2
             }
         } else if (tries == 4) {
             Logger << kINFO << "    ----> trying with improve" << GEndl;
@@ -1933,15 +1931,15 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
             algorithm = "migradimproved";
         }
     }
-    
+
     std::unique_ptr<RooFitResult> res(minim.save());
     if( requireGoodCovQual && res->covQual() != 3 && !hesse ) {
         Logger << kINFO << "status OK but covariance matrix not at full accuracy, will retry with HESSE to improve" << GEndl;
         hesse = true;
     }
 
-    RooFitResult * result = 0; 
-    
+    RooFitResult * result = 0;
+
     if (status%100 == 0 ) { // ignore errors in Hesse or in Improve
         // only calculate minos errors if fit with Migrad converged
         Logger << kINFO <<  "status: " << status << ", hesse = " << hesse <<" minos = " << minos << " minosPars = " << minosPars << GEndl;
@@ -1960,7 +1958,7 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
         // ignore errors in Hesse or in Improve if minos option not activated
         result  = minim.save();
     }
-    else { 
+    else {
         Logger << kERROR << "FIT FAILED !- return a NaN NLL " << GEndl;
     }
 
@@ -1975,7 +1973,7 @@ Util::doFreeFit( RooWorkspace* w, RooDataSet* inputdata, const bool& verbose, co
 
 
 //________________________________________________________________________________________________
-    RooMCStudy* 
+    RooMCStudy*
 Util::GetMCStudy( const RooWorkspace* w )
 {
     if (w==0) {
@@ -2008,10 +2006,10 @@ Util::GetMCStudy( const RooWorkspace* w )
 
 //________________________________________________________________________________________________
 // ATLAS specific - FIXME ; remove for public release
-void Util::ATLASLabel(Double_t x,Double_t y,const char* text,Color_t color) 
+void Util::ATLASLabel(Double_t x,Double_t y,const char* text,Color_t color)
 {
 
-    TLatex l; 
+    TLatex l;
     l.SetNDC();
     l.SetTextFont(72);
     l.SetTextColor(color);
@@ -2020,7 +2018,7 @@ void Util::ATLASLabel(Double_t x,Double_t y,const char* text,Color_t color)
 
     l.DrawLatex(x,y,"ATLAS");
     if (text) {
-        TLatex p; 
+        TLatex p;
         p.SetNDC();
         p.SetTextFont(42);
         p.SetTextColor(color);
@@ -2031,10 +2029,10 @@ void Util::ATLASLabel(Double_t x,Double_t y,const char* text,Color_t color)
 
 
 //________________________________________________________________________________________________
-void Util::AddText(Double_t x,Double_t y,char* text,Color_t color) 
+void Util::AddText(Double_t x,Double_t y,char* text,Color_t color)
 {
 
-    TLatex l; 
+    TLatex l;
     l.SetNDC();
     l.SetTextFont(72);
     l.SetTextColor(color);
@@ -2042,7 +2040,7 @@ void Util::AddText(Double_t x,Double_t y,char* text,Color_t color)
     double delx = 0.115*696*gPad->GetWh()/(472*gPad->GetWw());
 
     if (text) {
-        TLatex p; 
+        TLatex p;
         p.SetNDC();
         p.SetTextFont(42);
         p.SetTextColor(color);
@@ -2070,14 +2068,14 @@ void Util::AddTextLabel(Double_t x, Double_t y, const char* text, Color_t color)
 }
 
 //_____________________________________________________________________________
-RooAbsReal* Util::GetComponent(RooWorkspace* w, TString component, TString region, bool exactRegionName, TString rangeName){ 
+RooAbsReal* Util::GetComponent(RooWorkspace* w, TString component, TString region, bool exactRegionName, TString rangeName){
 
     std::vector<TString> componentVec = Tokens(component,",");
     if(componentVec.size() <1) { Logger << kWARNING << " componentVec.size() < 1, for components = " << component << GEndl; }
 
-    if(w==NULL){ 
-        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl; 
-        return NULL; 
+    if(w==NULL){
+        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl;
+        return NULL;
     }
 
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
@@ -2092,14 +2090,14 @@ RooAbsReal* Util::GetComponent(RooWorkspace* w, TString component, TString regio
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
     RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionFullName.Data());
 
-    RooAbsData* data = (RooAbsData*)w->data("obsData"); 
+    RooAbsData* data = (RooAbsData*)w->data("obsData");
     TString dataCatLabel = Form("channelCat==channelCat::%s",regionFullName.Data());
     RooAbsData* regionData = (RooAbsData*) data->reduce(dataCatLabel.Data());
 
-    if(regionPdf==NULL || regionData==NULL){ 
+    if(regionPdf==NULL || regionData==NULL){
         Logger << kERROR << " Either the Pdf or the Dataset do not have an appropriate state for the region = " << region << ", check the Workspace file" << GEndl;
-        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
-        return NULL; 
+        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
+        return NULL;
     }
     RooRealVar* regionVar =(RooRealVar*) ((RooArgSet*) regionPdf->getObservables(*regionData))->find(Form("obs_x_%s",regionFullName.Data()));
 
@@ -2124,11 +2122,11 @@ RooAbsReal* Util::GetComponent(RooWorkspace* w, TString component, TString regio
                 compFuncList.add(*(RooProduct*)w->obj(regionCompNameVec[iReg]));
                 compCoefList.add(*regionBinWidth);
             }
-        }  
+        }
     }
 
     if (compFuncList.getSize()==0 || compCoefList.getSize()==0 || compCoefList.getSize()!=compFuncList.getSize()){
-        Logger << kERROR << " Something wrong with compFuncList or compCoefList in Util::GetComponent(w," << component << "," << region 
+        Logger << kERROR << " Something wrong with compFuncList or compCoefList in Util::GetComponent(w," << component << "," << region
             << ") " << GEndl << "         compFuncList.getSize() = " << compFuncList.getSize() << " compCoefList.getSize() = " << compCoefList.getSize() << GEndl;
         return NULL;
     }
@@ -2182,13 +2180,13 @@ RooAbsReal* Util::GetComponent(RooWorkspace* w, TString component, TString regio
 Double_t Util::GetComponentFracInRegion(RooWorkspace* w, TString component, TString region){
 
     std::vector<TString> componentVec = Tokens(component,",");
-    if(componentVec.size() <1) { 
-        Logger << kWARNING << " componentVec.size() < 1, for components = " << component << GEndl; 
+    if(componentVec.size() <1) {
+        Logger << kWARNING << " componentVec.size() < 1, for components = " << component << GEndl;
     }
 
-    if(w==NULL){ 
-        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl; 
-        return 0; 
+    if(w==NULL){
+        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl;
+        return 0;
     }
 
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
@@ -2197,14 +2195,14 @@ Double_t Util::GetComponentFracInRegion(RooWorkspace* w, TString component, TStr
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
     RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionFullName.Data());
 
-    RooAbsData* data = (RooAbsData*)w->data("obsData"); 
+    RooAbsData* data = (RooAbsData*)w->data("obsData");
     TString dataCatLabel = Form("channelCat==channelCat::%s",regionFullName.Data());
     RooAbsData* regionData = (RooAbsData*) data->reduce(dataCatLabel.Data());
 
-    if(regionPdf==NULL || regionData==NULL){ 
+    if(regionPdf==NULL || regionData==NULL){
         Logger << kERROR << " Either the Pdf or the Dataset do not have an appropriate state for the region = " << region << ", check the Workspace file" << GEndl;
-        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
-        return 0; 
+        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
+        return 0;
     }
 
     RooRealVar* regionVar =(RooRealVar*) ((RooArgSet*) regionPdf->getObservables(*regionData))->find(Form("obs_x_%s",regionFullName.Data()));
@@ -2229,7 +2227,7 @@ Double_t Util::GetComponentFracInRegion(RooWorkspace* w, TString component, TStr
                 compFuncList.add(*(RooProduct*)w->obj(regionCompNameVec[iReg]));
                 compCoefList.add(*regionBinWidth);
             }
-        } 
+        }
     }
 
     if (compFuncList.getSize()==0 || compCoefList.getSize()==0 || compCoefList.getSize()!=compFuncList.getSize()){
@@ -2243,7 +2241,7 @@ Double_t Util::GetComponentFracInRegion(RooWorkspace* w, TString component, TStr
     }
 
     // get the full RRSPdf of this region
-    TString RRSPdfName = Form("%s_model",regionFullName.Data()); 
+    TString RRSPdfName = Form("%s_model",regionFullName.Data());
 
     double componentFrac = 0.;
     for(unsigned int iReg=0; iReg<regionCompNameVec.size(); iReg++){
@@ -2263,9 +2261,9 @@ Double_t Util::GetComponentFracInRegion(RooWorkspace* w, TString component, TStr
 //_____________________________________________________________________________
 RooAbsPdf* Util::GetRegionPdf(RooWorkspace* w, TString region){  //, unsigned int bin){
 
-    if(w==NULL){ 
-        Logger << kERROR << " Workspace not found, no GetRegionPdf performed" << GEndl; 
-        return NULL; 
+    if(w==NULL){
+        Logger << kERROR << " Workspace not found, no GetRegionPdf performed" << GEndl;
+        return NULL;
     }
 
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
@@ -2274,10 +2272,10 @@ RooAbsPdf* Util::GetRegionPdf(RooWorkspace* w, TString region){  //, unsigned in
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
     RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionFullName.Data());
 
-    if(regionPdf==NULL){ 
+    if(regionPdf==NULL){
         Logger << kERROR << " The Simultaneous Pdf  does not have an appropriate state for the region = " << region << ", check the Workspace file" << GEndl;
-        Logger << kERROR << " regionPdf = " << regionPdf << GEndl;  
-        return NULL; 
+        Logger << kERROR << " regionPdf = " << regionPdf << GEndl;
+        return NULL;
     }
 
     return regionPdf;
@@ -2286,11 +2284,11 @@ RooAbsPdf* Util::GetRegionPdf(RooWorkspace* w, TString region){  //, unsigned in
 
 
 //_____________________________________________________________________________
-RooRealVar* Util::GetRegionVar(RooWorkspace* w, TString region){ 
+RooRealVar* Util::GetRegionVar(RooWorkspace* w, TString region){
 
-    if(w==NULL){ 
-        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl; 
-        return NULL; 
+    if(w==NULL){
+        Logger << kERROR << " Workspace not found, no GetComponent performed" << GEndl;
+        return NULL;
     }
 
     RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
@@ -2299,14 +2297,14 @@ RooRealVar* Util::GetRegionVar(RooWorkspace* w, TString region){
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
     RooAbsPdf* regionPdf = (RooAbsPdf*) pdf->getPdf(regionFullName.Data());
 
-    RooAbsData* data = (RooAbsData*)w->data("obsData"); 
+    RooAbsData* data = (RooAbsData*)w->data("obsData");
     TString dataCatLabel = Form("channelCat==channelCat::%s",regionFullName.Data());
     RooAbsData* regionData = (RooAbsData*) data->reduce(dataCatLabel.Data());
 
-    if(regionPdf==NULL || regionData==NULL){ 
+    if(regionPdf==NULL || regionData==NULL){
         Logger << kERROR << " Either the Pdf or the Dataset do not have an appropriate state for the region = " << region << ", check the Workspace file" << GEndl;
-        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;  
-        return NULL; 
+        Logger << kERROR << " regionPdf = " << regionPdf << "   regionData = " << regionData << GEndl;
+        return NULL;
     }
     RooRealVar* regionVar =(RooRealVar*) ((RooArgSet*) regionPdf->getObservables(*regionData))->find(Form("obs_x_%s",regionFullName.Data()));
 
@@ -2326,14 +2324,14 @@ TString Util::GetFullRegionName(RooCategory* regionCat,  TString regionShortName
         if( regionsAllVec[iReg].Contains(regionShortName) && foundReg==0) {
             regionFullName = regionsAllVec[iReg];
             foundReg++;
-        } 
+        }
         else if( regionsAllVec[iReg].Contains(regionShortName) && foundReg>0){
-            foundReg++;     
+            foundReg++;
         }
     }
 
     if(foundReg>1)
-        Logger << kWARNING << "Util.GetFullRegionName() found more then one region in workspace with shortname = " << regionShortName 
+        Logger << kWARNING << "Util.GetFullRegionName() found more then one region in workspace with shortname = " << regionShortName
             << " \n Please use full region names (like WREl_meffInc) insted of shortnames (like WR) " << GEndl;
 
     return regionFullName;
@@ -2342,13 +2340,13 @@ TString Util::GetFullRegionName(RooCategory* regionCat,  TString regionShortName
 //__________________________________________________________________________________________
 vector<TString> Util::GetAllComponentNamesInRegion(TString region, RooAbsPdf* regionPdf){
 
-    TString RRSPdfName = Form("%s_model",region.Data()); 
+    TString RRSPdfName = Form("%s_model",region.Data());
     RooRealSumPdf* RRSPdf = (RooRealSumPdf*) regionPdf->getComponents()->find(RRSPdfName);
 
     if(RRSPdf==NULL){
         Logger << kERROR << " Util::GetAllComponentNamesInRegion() cannot find a RooRealSumPdf named " <<  RRSPdfName << GEndl ;
         vector<TString> vec;
-        return vec; 
+        return vec;
     }
 
     RooArgList RRSComponentsList =  RRSPdf->funcList();
@@ -2358,7 +2356,7 @@ vector<TString> Util::GetAllComponentNamesInRegion(TString region, RooAbsPdf* re
     vector<TString> compNameVec;
     compNameVec.clear();
 
-    while( (component = (RooProduct*) iter.Next())) { 
+    while( (component = (RooProduct*) iter.Next())) {
         TString  componentName = component->GetName();
         compNameVec.push_back(componentName);
     }
@@ -2372,7 +2370,7 @@ vector<TString> Util::GetAllComponentNamesInRegion(TString region, RooAbsPdf* re
 //__________________________________________________________________________________________
 vector<double> Util::GetAllComponentFracInRegion(RooWorkspace* w, TString region, RooAbsPdf* regionPdf, RooRealVar* obsRegion,RooRealVar* regionBinWidth){
 
-    TString RRSPdfName = Form("%s_model",region.Data()); 
+    TString RRSPdfName = Form("%s_model",region.Data());
     RooRealSumPdf* RRSPdf = (RooRealSumPdf*) regionPdf->getComponents()->find(RRSPdfName);
 
     RooArgList RRSComponentsList =  RRSPdf->funcList();
@@ -2382,7 +2380,7 @@ vector<double> Util::GetAllComponentFracInRegion(RooWorkspace* w, TString region
     vector<double> compFracVec;
     compFracVec.clear();
 
-    while( (component = (RooProduct*) iter.Next())) { 
+    while( (component = (RooProduct*) iter.Next())) {
         TString  componentName = component->GetName();
         double componentFrac = GetComponentFrac(w,componentName,RRSPdfName,obsRegion,regionBinWidth) ;
         compFracVec.push_back(componentFrac);
@@ -2397,11 +2395,11 @@ vector<double> Util::GetAllComponentFracInRegion(RooWorkspace* w, TString region
  * by Wouter Verkerke
  * See: http://root.cern.ch/root/html534/src/RooAbsReal.h.html
  * (http://roofit.sourceforge.net/license.txt)
- */ 
+ */
 
 
 //_____________________________________________________________________________
-double Util::GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const bool& doAsym) 
+double Util::GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const bool& doAsym)
 {
     Logger << kDEBUG << " GPP for variable = " << var->GetName() << GEndl;
 
@@ -2424,7 +2422,7 @@ double Util::GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const b
         }
     }
 
-    vector<Double_t> plusVar, minusVar ;   
+    vector<Double_t> plusVar, minusVar ;
 
     TMatrixDSym V( fr.covarianceMatrix() ) ;
 
@@ -2458,7 +2456,7 @@ double Util::GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const b
 
     }
 
-    TMatrixDSym C(paramList.getSize()) ;     
+    TMatrixDSym C(paramList.getSize()) ;
     vector<double> errVec(paramList.getSize()) ;
     for (int i=0 ; i<paramList.getSize() ; i++) {
         int newII = fpf_idx[i];
@@ -2485,7 +2483,7 @@ double Util::GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const b
     // Calculate error in linear approximation from variations and correlation coefficient
     Double_t sum = F*(C*F) ;
 
-    Logger << kDEBUG << " GPP : sum = " << sqrt(sum) << GEndl; 
+    Logger << kDEBUG << " GPP : sum = " << sqrt(sum) << GEndl;
 
     return sqrt(sum) ;
 }
@@ -2546,7 +2544,7 @@ Util::resetAllNominalValues( RooWorkspace* wspace )
 
 
 //_____________________________________________________________________________
-RooArgList 
+RooArgList
 Util::getFloatParList( const RooAbsPdf& pdf, const RooArgSet& obsSet )
 {
     RooArgList floatParList;
@@ -2569,8 +2567,8 @@ Util::getFloatParList( const RooAbsPdf& pdf, const RooArgSet& obsSet )
 
 
 //_____________________________________________________________________________
-void 
-Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgList& vetoList ) 
+void
+Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgList& vetoList )
 
 {
     /// For the given workspace,
@@ -2609,10 +2607,10 @@ Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgL
             throw -1;
         }
         // If it is a standard (gaussian) uncertainty
-        else if( string(UncertaintyName).find("alpha")!=string::npos ){ 
+        else if( string(UncertaintyName).find("alpha")!=string::npos ){
             // Assume the values are +1, -1
             val_hi  =  1.0;
-            val_low = -1.0;      
+            val_low = -1.0;
             sigma = 1.0;
             resetRange = true;
         }
@@ -2635,7 +2633,7 @@ Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgL
             double val_nom = nominalLumi->getVal();
 
             val_hi  = val_nom + sigma;
-            val_low = val_nom - sigma; 
+            val_low = val_nom - sigma;
             resetRange = true;
         }
         // If it is a stat uncertainty (gamma)
@@ -2667,7 +2665,7 @@ Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgL
                 val_hi = 1 + sigma;
                 val_low = 1 - sigma;
                 resetRange = true;
-            } 
+            }
             else {
                 Logger << kERROR << "Strange constraint type for Stat Uncertainties: " << ConstraintType << GEndl;
                 throw -1;
@@ -2770,8 +2768,8 @@ Util::resetValue( RooWorkspace* wspace, const RooArgList& parList, const RooArgL
 
 
 //_____________________________________________________________________________
-    void 
-Util::resetNominalValue( RooWorkspace* wspace, const RooArgSet& globSet ) 
+    void
+Util::resetNominalValue( RooWorkspace* wspace, const RooArgSet& globSet )
 {
     /// For the given workspace,
     /// find the input systematic with
@@ -2841,7 +2839,7 @@ void Util::ImportInWorkspace( RooWorkspace* wspace, TObject* obj, TString name) 
 
     // save snapshot
     RooSimultaneous* pdf = (RooSimultaneous*) wspace->pdf("simPdf");
-    RooAbsData* data = (RooAbsData*)wspace->data("obsData"); 
+    RooAbsData* data = (RooAbsData*)wspace->data("obsData");
     RooArgSet* params = (RooArgSet*) pdf->getParameters(*data) ;
 
     wspace->saveSnapshot(Form("snapshot_paramsVals_%s",name.Data()),*params);
@@ -2878,25 +2876,25 @@ void Util::RemoveEmptyDataBins( RooPlot* frame){
 
 RooHist* Util::MakeRatioOrPullHist(RooAbsData *regionData, RooAbsPdf *regionPdf, RooRealVar *regionVar, bool makePull /*false*/) {
 	// data/pdf ratio histograms are plotted by RooPlot.ratioHist() through a dummy frame
-	RooPlot* frame_dummy = regionVar->frame(); 
+	RooPlot* frame_dummy = regionVar->frame();
 	regionData->plotOn(frame_dummy, RooFit::DataError(RooAbsData::Poisson));
-	
+
 	// normalize pdf to number of expected events, not to number of events in dataset
-	regionPdf->plotOn(frame_dummy, RooFit::Normalization(1, RooAbsReal::RelativeExpected), 
+	regionPdf->plotOn(frame_dummy, RooFit::Normalization(1, RooAbsReal::RelativeExpected),
 								     RooFit::Precision(1e-5));
 
-	if(makePull) {	
+	if(makePull) {
         //return static_cast<RooHist*>(frame_dummy->pullHist());
         return static_cast<RooHist*>(frame_dummy->pullHist());
 	}
-		
+
     return static_cast<RooHist*>(frame_dummy->ratioHist());
 }
 
 //________________________________________________________________________________________________________________________________________
 RooCurve* Util::MakePdfErrorRatioHist(RooAbsData* regionData, RooAbsPdf* regionPdf, RooRealVar* regionVar, RooFitResult* rFit, Double_t Nsigma){
 
-    RooPlot* frame = regionVar->frame(); 
+    RooPlot* frame = regionVar->frame();
     regionData->plotOn(frame, RooFit::DataError(RooAbsData::Poisson));
 
     // normalize pdf to number of expected events, not to number of events in dataset
@@ -2908,10 +2906,10 @@ RooCurve* Util::MakePdfErrorRatioHist(RooAbsData* regionData, RooAbsPdf* regionP
     }
 
     if(rFit != NULL) {
-        regionPdf->plotOn(frame, Normalization(1, RooAbsReal::RelativeExpected), 
-                                 Precision(1e-5), 
-                                 FillColor(kBlue-5), 
-                                 FillStyle(3004), 
+        regionPdf->plotOn(frame, Normalization(1, RooAbsReal::RelativeExpected),
+                                 Precision(1e-5),
+                                 FillColor(kBlue-5),
+                                 FillStyle(3004),
                                  DrawOption("F"),
                                  VisualizeError(*rFit, Nsigma));
     }
@@ -2961,10 +2959,10 @@ RooCurve* Util::MakePdfErrorRatioHist(RooAbsData* regionData, RooAbsPdf* regionP
         }
 
         // only divide by yNom if it is non-zero
-        if(  fabs(yNom) > 0.00001 ){ 
-            ratioBand->addPoint(x, (y / yNom));  
-        } else { 
-            ratioBand->addPoint(x, 0.);             
+        if(  fabs(yNom) > 0.00001 ){
+            ratioBand->addPoint(x, (y / yNom));
+        } else {
+            ratioBand->addPoint(x, 0.);
         }
     }
 
@@ -3011,20 +3009,20 @@ void Util::SetPdfParError(RooWorkspace* w, double Nsigma){
 //_____________________________________________________________________________
 RooAbsReal* Util::CreateNLL( RooWorkspace* w, TString fitRegions, Bool_t lumiConst)
 {
-    if(w==NULL){ 
+    if(w==NULL){
         Logger << kERROR << "Workspace not found, no fitting performed" << GEndl;
-        return NULL; 
+        return NULL;
     }
     RooSimultaneous* pdf = (RooSimultaneous*) w->pdf("simPdf");
 
-    RooAbsData* data = (RooAbsData*)w->data("obsData") ; 
-    RooCategory* regionCat = (RooCategory*) w->cat("channelCat");  
+    RooAbsData* data = (RooAbsData*)w->data("obsData") ;
+    RooCategory* regionCat = (RooCategory*) w->cat("channelCat");
 
     data->table(*((RooAbsCategory*)regionCat))->Print("v");
 
     if (lumiConst) {
         RooRealVar* lumi = (RooRealVar*) w->var("Lumi");
-        if (lumi!=NULL) lumi->setConstant(lumiConst); 
+        if (lumi!=NULL) lumi->setConstant(lumiConst);
     }
 
     // Construct an empty simultaneous pdf using category regionCat as index
@@ -3039,8 +3037,8 @@ RooAbsReal* Util::CreateNLL( RooWorkspace* w, TString fitRegions, Bool_t lumiCon
 
     for(unsigned int iVec=0; iVec<numFitRegions; iVec++){
         TString regionCatLabel = fitRegionsVec[iVec];
-        if( regionCat->setLabel(regionCatLabel,kTRUE)){  
-            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl; 
+        if( regionCat->setLabel(regionCatLabel,kTRUE)){
+            Logger << kWARNING << " Label '" << regionCatLabel << "' is not a state of channelCat (see Table) " << GEndl;
         } else{
             // dataset for each channel/region/category
             TString dataCatLabel = Form("channelCat==channelCat::%s",regionCatLabel.Data());
@@ -3052,12 +3050,12 @@ RooAbsReal* Util::CreateNLL( RooWorkspace* w, TString fitRegions, Bool_t lumiCon
         }
     }
 
-    if(dataVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl; 
+    if(dataVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN DATASET, NO FIT WILL BE PERFORMED" << GEndl;
         return 0;
     }
-    else if(pdfVec.empty()){ 
-        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl; 
+    else if(pdfVec.empty()){
+        Logger << kERROR << "   NONE OF THE REGIONS ARE SPECIFIED IN SIMULTANEOUS PDF, NO FIT WILL BE PERFORMED" << GEndl;
         return 0;
     }
     else{
@@ -3079,7 +3077,7 @@ RooAbsReal* Util::CreateNLL( RooWorkspace* w, TString fitRegions, Bool_t lumiCon
     RooStats::ModelConfig* mc = Util::GetModelConfig( w );
     const RooArgSet* globObs = mc->GetGlobalObservables();
 
-    RooAbsReal* nll = (RooNLLVar*) pdf_FR->createNLL(*data_FR, RooFit::GlobalObservables(*globObs) ); 
+    RooAbsReal* nll = (RooNLLVar*) pdf_FR->createNLL(*data_FR, RooFit::GlobalObservables(*globObs) );
 
     return nll;
 }
@@ -3095,7 +3093,7 @@ Util::scanStrForFloats(const TString& toscan, const TString& format)
 
     int narg2 = sscanf( toscan.Data(), format.Data(), &wsarg[0],&wsarg[1],&wsarg[2],&wsarg[3],&wsarg[4],&wsarg[5],&wsarg[6],&wsarg[7],&wsarg[8],&wsarg[9] );
 
-    if ( !(narg1==narg2 && narg2>0) ) { 
+    if ( !(narg1==narg2 && narg2>0) ) {
         Logger << kERROR << "Util::scanStringForFloats incorrect lengths" << GEndl;
         return wsid;
     }
@@ -3104,7 +3102,7 @@ Util::scanStrForFloats(const TString& toscan, const TString& format)
     wsid.Clear();  // form unique ws id
     for (int i=0; i<narg2; ++i) {
         if (i!=0) wsid += "_" ;
-        wsid += Form("%.0f", wsarg[i] ); 
+        wsid += Form("%.0f", wsarg[i] );
     }
 
     return wsid;
@@ -3159,7 +3157,7 @@ TGraph* Util::getErrorBand(TH1F* hNom, TH1F* hHigh, TH1F* hLow){
       else{
         if(hNom->GetBinContent(i) == hHigh->GetBinContent(i)){
           if(hNom->GetBinContent(i)>hLow->GetBinContent(i)){
-            high.push_back(0.);  
+            high.push_back(0.);
             low.push_back(hNom->GetBinContent(i)-hLow->GetBinContent(i));
           }
           else{
@@ -3186,9 +3184,9 @@ TGraph* Util::getErrorBand(TH1F* hNom, TH1F* hHigh, TH1F* hLow){
      g->SetPoint(2*i,X[i]-ErrXl[i],nom[i]+high[i]);
      g->SetPoint(2*i+1,X[i]+ErrXh[i],nom[i]+high[i]);
    }
-   
+
    int Ntmp = g->GetN();
-   
+
    for(unsigned int i=0;i<X.size();i++){
     g->SetPoint(Ntmp+2*i,X[X.size()-1-i]+ErrXh[X.size()-1-i],nom[X.size()-1-i]-low[X.size()-1-i]);
     g->SetPoint(Ntmp+2*i+1,X[X.size()-1-i]-ErrXl[X.size()-1-i],nom[X.size()-1-i]-low[X.size()-1-i]);
@@ -3197,14 +3195,14 @@ TGraph* Util::getErrorBand(TH1F* hNom, TH1F* hHigh, TH1F* hLow){
    g->SetFillColor(kYellow);
 
    return g;
- 
+
 }
 
 void Util::plotDistribution(TFile* f, TString hNomName, TString Syst, TString NameSample, TString Region, TString Var){
 
 
    TH1F* hNom = (TH1F*)f->Get(hNomName);
-   
+
    TString syst_name = Syst;
    TString norm = "";
    if (syst_name.EndsWith("Norm")) {
@@ -3229,7 +3227,7 @@ void Util::plotDistribution(TFile* f, TString hNomName, TString Syst, TString Na
    for(int i=1;i<=hNomClone->GetNbinsX();i++){
        if(hNom->GetBinContent(i)>0) hNomClone->SetBinError(i,hNom->GetBinError(i)/hNom->GetBinContent(i));
        hNomClone->SetBinContent(i,1);
-       
+
    }
 
    TH1F* hHighClone = (TH1F*)hHigh->Clone();
@@ -3242,12 +3240,12 @@ void Util::plotDistribution(TFile* f, TString hNomName, TString Syst, TString Na
    for(int i=1;i<=hLowClone->GetNbinsX();i++){
        hLowClone->SetBinError(i,0.);
    }
-   
+
    for(int i=1;i<=hNom->GetNbinsX();i++){
       if(hNom->GetBinContent(i)<=0){
         if(hLow->GetBinContent(i)<=0 && hHigh->GetBinContent(i)<=0){
              hLowClone->SetBinContent(i,1.);
-             hHighClone->SetBinContent(i,1); 
+             hHighClone->SetBinContent(i,1);
         }
         else if(hLow->GetBinContent(i)<=0 && hHigh->GetBinContent(i)>0) hHighClone->SetBinContent(i,10);
         else if(hLow->GetBinContent(i)>0 && hHigh->GetBinContent(i)<=0) hLowClone->SetBinContent(i,10);
@@ -3261,12 +3259,12 @@ void Util::plotDistribution(TFile* f, TString hNomName, TString Syst, TString Na
             hHighClone->SetBinContent(i,1.);
          }
         }
-        
+
       }
    }
 
-   
-  
+
+
 
    TCanvas* c = new TCanvas(NameSample+"_"+Syst+"Syst_"+Region+"_Dist",NameSample+" "+Syst+" Syst ("+Region+") Dist",600,400);
 
@@ -3313,22 +3311,22 @@ void Util::plotDistribution(TFile* f, TString hNomName, TString Syst, TString Na
    pad2->SetBottomMargin(0.2);
    pad2->Draw();
    pad2->cd();
-  
+
    TGraph* gClone = getErrorBand(hNomClone,hHighClone,hLowClone);
-   gClone->GetXaxis()->SetLabelSize(0.08);  
+   gClone->GetXaxis()->SetLabelSize(0.08);
    gClone->GetXaxis()->SetTitleSize(0.08);
    gClone->GetXaxis()->SetTitle(Var);
    gClone->GetYaxis()->SetTitle("#Delta X/X[%]");
    gClone->GetYaxis()->SetTitleOffset(0.5);
    gClone->GetYaxis()->SetTitleSize(0.08);
    gClone->GetYaxis()->SetRangeUser(0,2.);
-   gClone->GetYaxis()->SetLabelSize(0.06);  
+   gClone->GetYaxis()->SetLabelSize(0.06);
    double minY=11., maxY=0;
    for(int i=0;i<gClone->GetN();i++){
       double x,y;
       gClone->GetPoint(i,x,y);
       if(y<minY) minY=y;
-      if(y>maxY) maxY=y;     
+      if(y>maxY) maxY=y;
    }
    if(maxY>2.) maxY=2.;
    gClone->GetYaxis()->SetRangeUser(minY-0.01,maxY+0.01);
@@ -3373,8 +3371,8 @@ void Util::plotSystematics(TFile* f,TString hNomName, vector<TString> Syst, TStr
         syst_name.ReplaceAll("Norm","");
         norm = "Norm";
       }
-      
-       
+
+
       hSystNom->SetBinContent(i,Nom);
       TString hHighName = hNomName;
       hHighName.ReplaceAll("Nom",syst_name+"High");
@@ -3384,7 +3382,7 @@ void Util::plotSystematics(TFile* f,TString hNomName, vector<TString> Syst, TStr
       hLowName.ReplaceAll("Nom",syst_name+"Low");
       TH1F* hL = (TH1F*)f->Get(hLowName+norm);
 
-      if(!hH || !hL){ 
+      if(!hH || !hL){
         Logger << kWARNING << syst_name <<" systematic (with or without normalization) has not been found" << GEndl;
         hSystHigh->SetBinContent(i,Nom);
         hSystLow->SetBinContent(i,Nom);
@@ -3470,7 +3468,7 @@ void Util::plotUpDown(TString FileName, TString NameSample, TString SystName, TS
 
 
   if(NBins>0){
-   for(unsigned int i=0;i<Syst.size();i++) plotDistribution(f,hNomName,Syst[i],NameSample,Region,Var);    
+   for(unsigned int i=0;i<Syst.size();i++) plotDistribution(f,hNomName,Syst[i],NameSample,Region,Var);
   }
 
   plotSystematics(f,hNomName,Syst,NameSample,Region,Var);
@@ -3480,7 +3478,7 @@ void Util::plotUpDown(TString FileName, TString NameSample, TString SystName, TS
 
  //f->Close();
  //delete f;
-   
+
 }
 
 //-------------------------------------------------------------------------------------------------------
@@ -3548,8 +3546,8 @@ void Util::PlotFitParameters(RooFitResult* r, TString anaName){
  parLowErrors.insert(parLowErrors.end(), alpha_parLowErrors.begin(), alpha_parLowErrors.end());
  parLowErrors.insert(parLowErrors.end(), mcstat_parLowErrors.begin(), mcstat_parLowErrors.end());
  parLowErrors.insert(parLowErrors.end(), mu_parLowErrors.begin(), mu_parLowErrors.end());
- 
- 
+
+
 
  TCanvas* c_np = new TCanvas("fit_parameters","fit_parameters",1200,800);
  c_np->cd();
@@ -3558,7 +3556,7 @@ void Util::PlotFitParameters(RooFitResult* r, TString anaName){
  p_np->Draw();
  p_np->cd();
 
- TGraphAsymmErrors* g = new TGraphAsymmErrors(N.size(),&(parVals[0]),&(N[0]),&(parLowErrors[0]),&(parHighErrors[0]),&(errN[0]),&(errN[0])); 
+ TGraphAsymmErrors* g = new TGraphAsymmErrors(N.size(),&(parVals[0]),&(N[0]),&(parLowErrors[0]),&(parHighErrors[0]),&(errN[0]),&(errN[0]));
  g->GetHistogram()->GetYaxis()->Set(count/2,1,count+1);
  for(unsigned int i=1;i<=N.size();i++) g->GetHistogram()->GetYaxis()->SetBinLabel(i,parNames[i-1]);
  g->GetHistogram()->GetYaxis()->SetRangeUser(1,count+1);
@@ -3586,7 +3584,7 @@ void Util::PlotFitParameters(RooFitResult* r, TString anaName){
  _parLowErrors.insert(_parLowErrors.end(), mcstat_parLowErrors.begin(), mcstat_parLowErrors.end());
  _parLowErrors.insert(_parLowErrors.end(), mu_parLowErrors.begin(), mu_parLowErrors.end());
 
- TGraph* _g = new TGraph(_N.size(),&(_parVals[0]),&(_N[0])); 
+ TGraph* _g = new TGraph(_N.size(),&(_parVals[0]),&(_N[0]));
  _g->SetName("_fit_results");
  _g->SetTitle("");
  _g->SetMarkerStyle(8);
@@ -3600,12 +3598,12 @@ void Util::PlotFitParameters(RooFitResult* r, TString anaName){
  yMCstatBand->SetPoint(1,-1,count+2);
  yMCstatBand->SetPoint(2,1,count+2);
  yMCstatBand->SetPoint(3,1,0);
- yMCstatBand->SetFillColor(kYellow); 
- yMCstatBand->SetFillStyle(3352); 
+ yMCstatBand->SetFillColor(kYellow);
+ yMCstatBand->SetFillStyle(3352);
 
  TLine* lMCstat = new TLine(0,1,0,count+1);
  lMCstat->SetLineStyle(8);
- c_np->Update(); 
+ c_np->Update();
 
  TGaxis *axis1 = new TGaxis(p_np->GetUxmin(),p_np->GetUymax(),p_np->GetUxmax(),p_np->GetUymax(),p_np->GetUxmin()+1,p_np->GetUxmax()+1,510,"-L");
  axis1->SetLineColor(kBlue);
@@ -3619,7 +3617,7 @@ void Util::PlotFitParameters(RooFitResult* r, TString anaName){
  g->Draw("Psame");
  _g->Draw("Psame");
 
- c_np->SaveAs("results/"+anaName+"/"+c_np->GetName()+".root"); 
+ c_np->SaveAs("results/"+anaName+"/"+c_np->GetName()+".root");
 
 }
 
@@ -3632,7 +3630,7 @@ TH1* Util::ComponentToHistogram(RooRealSumPdf* component, RooRealVar* variable, 
     auto stepsize = variable->getBinning().averageBinWidth();
     auto hist = component->createHistogram(Form("hist_%s", component->GetName()), *variable);
 
-    // Now loop over the bins and fill them 
+    // Now loop over the bins and fill them
     for(int i=0; i < hist->GetNbinsX()+2; ++i) {
         auto low = hist->GetBinLowEdge(i);
         auto width = hist->GetBinWidth(i);
@@ -3653,7 +3651,7 @@ TH1* Util::ComponentToHistogram(RooRealSumPdf* component, RooRealVar* variable, 
     }
 
     auto sum = component->createIntegral(RooArgSet(*variable))->getVal();
-    
+
     double scale = 0.0;
     if(sum != 0 && hist->Integral() != 0) {
         scale = sum / hist->Integral();
@@ -3664,10 +3662,10 @@ TH1* Util::ComponentToHistogram(RooRealSumPdf* component, RooRealVar* variable, 
     return hist;
 }
 
-void Util::ScaleGraph(TGraphAsymmErrors *g, TH1* h) { 
+void Util::ScaleGraph(TGraphAsymmErrors *g, TH1* h) {
     if (g->GetN() != h->GetNbinsX() ) {
-        Logger << kERROR << "Cannot multiply graph with " << g->GetN() << " points with histogram with " << h->GetNbinsX() << " points" << GEndl ; 
-        throw 1 ; 
+        Logger << kERROR << "Cannot multiply graph with " << g->GetN() << " points with histogram with " << h->GetNbinsX() << " points" << GEndl ;
+        throw 1 ;
     }
 
     for(int i=0; i < g->GetN(); ++i) {
@@ -3675,7 +3673,7 @@ void Util::ScaleGraph(TGraphAsymmErrors *g, TH1* h) {
         int j = i+1;
 
         double x, y;
-        g->GetPoint(i, x, y); 
+        g->GetPoint(i, x, y);
 
         g->SetPoint(i, x, y * h->GetBinContent(j));
         g->SetPointEYhigh(i, g->GetErrorYhigh(i) * h->GetBinContent(j));
@@ -3702,7 +3700,7 @@ void Util::plotInterpolationScheme(RooWorkspace *w) {
 
     RooAbsArg* parg(0);
     while((parg=(RooAbsArg*)iter->Next())) {
-        if ( parg->ClassName()!=TString("PiecewiseInterpolation") ) { continue; }    
+        if ( parg->ClassName()!=TString("PiecewiseInterpolation") ) { continue; }
         PiecewiseInterpolation* p = (PiecewiseInterpolation*)w->function( parg->GetName() );
         p->printAllInterpCodes();
         const RooArgList paramList =  p->paramList();
@@ -3768,4 +3766,3 @@ void Util::plotInterpolationScheme(RooWorkspace *w) {
     currentDir->cd();
 
 }
-

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -17,26 +17,26 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef Utils_hh
-#define Utils_hh
+#ifndef UTILS_H
+#define UTILS_H
 
 #include <map>
 #include <vector>
 #include <string>
+#include <iostream>
+
 #include "TString.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TFile.h"
 #include "TGraphAsymmErrors.h"
 
-#include <iostream>
 
 #include "RooFitResult.h"
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooExpandedFitResult.h"
 #include "ChannelStyle.h"
-
 class TMap;
 class TTree;
 
@@ -49,7 +49,6 @@ class RooAbsData;
 class RooSimultaneous;
 class RooCategory;
 class RooPlot;
-//class RooFitResult;
 class RooMCStudy;
 class FitConfig;
 class RooProdPdf;
@@ -74,7 +73,7 @@ namespace Util
   RooWorkspace* GetWorkspaceFromFile( const TString& infile, const TString& wsname );
   /**
      Wrute RooWorkspace to file
-  */ 
+  */
   void WriteWorkspace(RooWorkspace* w, TString outFileName="./results/BkgForumTest_combined_ComHistoSysOverConst_model.root", TString suffix = "");
   /**
      Load snapshot
@@ -90,10 +89,10 @@ namespace Util
   void ImportInWorkspace( RooWorkspace* wspace, TObject* obj=NULL, TString name="");
 
   /**
-    Decompose RooWorkspace into a separate object for each region, mainly decomposing simultaneous PDF/data 
+    Decompose RooWorkspace into a separate object for each region, mainly decomposing simultaneous PDF/data
   */
   void DecomposeWS(const char* infile, const char* wsname, const char* outfile);
-  
+
   /**
      Reset errors of all (nuisance/normalization) parameters in RooWorkspace to 'natural' values
   */
@@ -146,17 +145,17 @@ namespace Util
      @param fixedPars String of parameter1:value1,parameter2:value2 giving information on which parameter to fix to which value if dofixParameter == kTRUE, default=''
      @param noFit Don't re-run fit, but load parameter from after-fit workspace
      @param plotInterpolation plot the interpolation scheme
-  */  
-  void GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix, 
+  */
+  void GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
 			  Bool_t plotSeparateComponents, Bool_t plotNLL,  Bool_t minos = kFALSE, TString minosPars="", Bool_t doFixParameters = kFALSE, TString fixedPars="", bool ReduceCorrMatrix = true, bool noFit = false, bool plotInterpolation = false);
- 
+
   // Same as above, but now only for afterFit workspace
-  void GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix, 
+  void GeneratePlots(TString filename, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
           Bool_t plotSeparateComponents, Bool_t plotNLL, Bool_t minos, TString minosPars,
           Bool_t doFixParameters, TString fixedPars, bool ReduceCorrMatrix);
 
   /**
-     Function to plot each region with data, pdf and pdf-components(=samples)  
+     Function to plot each region with data, pdf and pdf-components(=samples)
      @param w RooWorkspace pointer
      @param fcName Fitconfig name as TString, pre-defined in RooWorkspace
      @param anaName Analysis name defined in config file, mainly used for output file/dir naming
@@ -164,17 +163,17 @@ namespace Util
      @param outputPrefix Output prefix, mainly used for TCanvas naming
      @param rFit RooFitResult pointer to plot the propagated uncertainty on the fitted model
      @param inputData RooAbsData pointer pointing to a toy/asimov-dataset, default='' meaning that it takes obsData from RooWorkspace
-  */   
-  void PlotPdfWithComponents(RooWorkspace* w, TString fcName = "Example3b", TString anaName="Analysis", TString plotRegions = "ALL", 
+  */
+  void PlotPdfWithComponents(RooWorkspace* w, TString fcName = "Example3b", TString anaName="Analysis", TString plotRegions = "ALL",
 			     TString outputPrefix = "", RooFitResult* rFit = NULL, RooAbsData* inputData=0);
   /**
-     Function to plot each region with data, pdf and pdf-components(=samples) 
-     @sa PlotPdfWithComponents() 
+     Function to plot each region with data, pdf and pdf-components(=samples)
+     @sa PlotPdfWithComponents()
 
-  */ 
-  void PlotPdfWithComponents(RooWorkspace* w, FitConfig* fc,  TString anaName="Analysis", TString plotRegions= "ALL", TString outputPrefix = "", 
+  */
+  void PlotPdfWithComponents(RooWorkspace* w, FitConfig* fc,  TString anaName="Analysis", TString plotRegions= "ALL", TString outputPrefix = "",
 			     RooFitResult* rFit= NULL, RooAbsData* inputData=0 );
- 
+
   /**
      Function to add components(=samples) in plot, called for each region in turn
      @param w RooWorkspace pointer
@@ -185,9 +184,9 @@ namespace Util
      @param regionCatLabel TString that defines this region in simultaneous pdf
      @param style Instance of ChannelStyle class defined for the FitConfig fc, that carries info on plot colors etc
   */
-  void AddComponentsToPlot(RooWorkspace* w,FitConfig* fc, RooPlot* frame, RooAbsPdf* regionPdf, 
+  void AddComponentsToPlot(RooWorkspace* w,FitConfig* fc, RooPlot* frame, RooAbsPdf* regionPdf,
 			   RooRealVar* obsRegion, TString regionCatLabel, ChannelStyle style);
-  
+
   /**
      Function to plot each component(=sample) separately in each region
      @param w RooWorkspace pointer
@@ -197,10 +196,10 @@ namespace Util
      @param outputPrefix Output prefix, mainly used for TCanvas naming
      @param rFit RooFitResult pointer to plot the propagated uncertainty on the fitted model
      @param inputData RooAbsData pointer pointing to a toy/asimov-dataset, default='' meaning that it takes obsData from RooWorkspace
-  */   
-  void PlotSeparateComponents(RooWorkspace* w, TString fcName = "Example3b", TString anaName="Analysis", TString plotRegions = "ALL", 
+  */
+  void PlotSeparateComponents(RooWorkspace* w, TString fcName = "Example3b", TString anaName="Analysis", TString plotRegions = "ALL",
 			      TString outputPrefix = "", RooFitResult* rFit = NULL, RooAbsData* inputData=0 );
-  
+
   /**
      Function to plot correlation matrix
      @param rFit RooFitResult pointer to get the correlation matrix for
@@ -215,7 +214,7 @@ namespace Util
      @param anaName Analysis name defined in config file, mainly used for output file/dir naming
   */
   TH2D* GetCorrelations(RooFitResult* rFit = NULL, double threshold = 0.9, TString anaName="Analysis");
- 
+
   /**
      Function to plot log-likelihood (NLL) and profile log-likelihood (PLL)
      @param w RooWorkspace pointer
@@ -228,9 +227,9 @@ namespace Util
      @param fitRegions Comma-separated input TString of regions used for the fit, hence also used to build the NLL/PLL (as also done in FitPdf())
      @param lumiConst Boolean deciding whether "Lumi" parameter (with a special treatment in HistFactory) is to be set constant or not (as also done in FitPdf())
   */
-  void PlotNLL(RooWorkspace* w, RooFitResult* rFit = NULL,  Bool_t plotPLL = false, TString anaName="Analysis", 
+  void PlotNLL(RooWorkspace* w, RooFitResult* rFit = NULL,  Bool_t plotPLL = false, TString anaName="Analysis",
 	       TString outputPrefix = "", RooAbsData* inputData=0, TString plotPars="", TString fitRegions="ALL", Bool_t lumiConst=false);
- 
+
   /**
      Function to construct a data/model ratio or pull
      @param regionPdf RooAbsPdf pointer to the total-pdf for this specific region
@@ -248,7 +247,7 @@ namespace Util
      @param rFit RooFitResult pointer used to construct +/-1 sigma curves
      @param Nsigma Number of sigmas to be plotted, default= 1.
   */
-  RooCurve* MakePdfErrorRatioHist(RooAbsData* regionData, RooAbsPdf* regionPdf, 
+  RooCurve* MakePdfErrorRatioHist(RooAbsData* regionData, RooAbsPdf* regionPdf,
 				  RooRealVar* regionVar, RooFitResult* rFit, Double_t Nsigma = 1.);
 
 
@@ -265,12 +264,12 @@ namespace Util
 
   */
   void ATLASLabel(Double_t x,Double_t y, const char* text=NULL,Color_t color=kBlack) ;
-  
+
   /**
      Add text to plot
   */
   void AddText(Double_t x,Double_t y,char* text=NULL,Color_t color=kBlack) ;
- 
+
   /**
      Add text to plot when streamed from steering macro
   */
@@ -281,10 +280,10 @@ namespace Util
      Remove empty bins for data (otherwise a Poisson error on 0 observed events is shown)
      @param frame RooPlot pointer for the frame that needs removing the empty bins
   */
- 
+
 
   void RemoveEmptyDataBins(RooPlot* frame);
-  
+
 
   // Fitting related functions
   /**
@@ -297,10 +296,10 @@ namespace Util
      @param minos Boolean deciding whether asymmetric errors are calculated, eg whether MINOS is run, default=kFALSE
      @param minosPars When minos is called, defining what parameters need asymmetric error calculation, default=''
      @param doFixParameters Boolean deciding if some parameters are fixed to a value given or not, default=kFalse
-     @param fixedPars String of parameter1:value1,parameter2:value2 giving information on which parameter to fix to which value if dofixParameter == kTrue, default=''    
+     @param fixedPars String of parameter1:value1,parameter2:value2 giving information on which parameter to fix to which value if dofixParameter == kTrue, default=''
      @return RooFitResult pointer continaing the fit result
   */
-  RooFitResult* FitPdf(RooWorkspace* w,  TString fitRegions="ALL", Bool_t lumiConst=false, RooAbsData* inputData=0, 
+  RooFitResult* FitPdf(RooWorkspace* w,  TString fitRegions="ALL", Bool_t lumiConst=false, RooAbsData* inputData=0,
 		       TString suffix ="", Bool_t minos = kFALSE, TString minosPars="", Bool_t doFixParameters = kFALSE, TString fixedPars="");
 
   /**
@@ -310,12 +309,12 @@ namespace Util
      @param doAsym Boolean deciding whether asymmetric (MINOS) errors on parameters get used in an averaged approximation
      @return Returns the propagated error
   */
-  double GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const bool& doAsym=false); 
-  
+  double GetPropagatedError(RooAbsReal* var, const RooFitResult& fr, const bool& doAsym=false);
+
   /**
-     Sets interpolation code  
+     Sets interpolation code
      @param w RooWorkspace pointer
-     @param code Typicaly set to code = 4, meaning parabolic interpolation (default now in RooStats). This avoids kinks in the likelihood curve. 
+     @param code Typicaly set to code = 4, meaning parabolic interpolation (default now in RooStats). This avoids kinks in the likelihood curve.
    */
   void SetInterpolationCode(RooWorkspace* w, Int_t code);
   /**
@@ -342,9 +341,9 @@ namespace Util
      @param hesse Boolean deciding whether to run HESSE or not; default=false
      @param minos Boolean deciding whether asymmetric errors are calculated, eg whether MINOS is run, default=kFALSE
      @param minosPars When minos is called, defining what parameters need asymmetric error calculation, default=''
-     @return RooFitResult pointer to fit result 
+     @return RooFitResult pointer to fit result
   */
-  RooFitResult* doFreeFit( RooWorkspace* w, RooDataSet* inputdata=0, const bool& verbose=false, 
+  RooFitResult* doFreeFit( RooWorkspace* w, RooDataSet* inputdata=0, const bool& verbose=false,
 			   const bool& resetAfterFit=false, bool hesse=false, Bool_t minos = kFALSE, TString minosPars="" );
   /**
      Get asimovData dataset from workspace
@@ -354,13 +353,13 @@ namespace Util
      Generate and return a toyMC set based on the PDF/obsData contained in ModelConfig in workspace. Number of generated events is equal to number of events in obsData.
   */
   RooAbsData* GetToyMC( RooWorkspace* inputws=0 ) ;
-  
- 
-  
+
+
+
   // Simultaneous PDF related functions, to (de)compose PDF and PDF components
   /**
      Get component (sample or mutiple samples as comma-separated string) in region.
-     Returns the integral of recomposed RooRealSumPdf (top-level region PDF in HistFactory); only in a specific range, if rangeName is given. 
+     Returns the integral of recomposed RooRealSumPdf (top-level region PDF in HistFactory); only in a specific range, if rangeName is given.
   */
   RooAbsReal* GetComponent(RooWorkspace* w, TString component, TString region, const bool exactRegionName=false, TString rangeName="");
   /**
@@ -380,7 +379,7 @@ namespace Util
      Get component (sample or multiple samples) fraction in region
   */
   Double_t GetComponentFracInRegion(RooWorkspace* w, TString component, TString region);
-  
+
   /**
      Get a vector of region names
   */
@@ -390,10 +389,10 @@ namespace Util
   */
   std::vector<TString> GetAllComponentNamesInRegion(TString region, RooAbsPdf* regionPdf);
   /**
-    Get all component (sample) fractions in region  
+    Get all component (sample) fractions in region
   */
   std::vector<double> GetAllComponentFracInRegion(RooWorkspace* w, TString region, RooAbsPdf* regionPdf, RooRealVar* obsRegion, RooRealVar* binWidth);
-  
+
   /**
      Get region name as used in RooCategory of the simultaneous PDF
   */
@@ -404,13 +403,13 @@ namespace Util
   double looseToTightVal(const TString& reg, TMap* map);
   double looseToTightErr(const TString& reg, TMap* map);
   double getNonQcdVal(const TString& proc, const TString& reg, TMap* map, const TString& opt);
-  
+
   std::vector<TString> Tokens(TString aline,TString aDelim);
   std::vector<TString> TokensALL(RooCategory* cat);
 
   TString scanStrForFloats(const TString& toscan, const TString& format);
 
- 
+
   // Functions for toy generation with ToyMCSampler
   /**
      Get parameter of interest (POI) out of ModelConfig in workspace
@@ -436,9 +435,9 @@ namespace Util
   @param Syst       -> Systematic Name
   @param NameSample -> Sample Name
   @param Region     -> Region:{ex. SR,CR,VR}
-  @param Var        -> Varible  
+  @param Var        -> Varible
   */
-  
+
   void plotDistribution(TFile* f, TString hNomName, TString Syst, TString NameSample, TString Region, TString Var);
 
   /**
@@ -448,7 +447,7 @@ namespace Util
   @param Syst       -> Systematics
   @param NameSample -> Sample Name
   @param Region     -> Region:{ex. SR,CR,VR}
-  @param Var        -> Varible  
+  @param Var        -> Varible
   */
 
  void plotSystematics(TFile* f,TString hNomName, std::vector<TString> Syst, TString NameSample, TString Region, TString Var);
@@ -459,7 +458,7 @@ namespace Util
   @param NameSample -> Sample Name
   @param SystName   -> List of the Systematics ex. JER,JES (a comma should be used to between each systematic)
   @param Region     -> Region:{ex. SR,CR,VR}
-  @param Var        -> Varible  
+  @param Var        -> Varible
   */
 
  void plotUpDown(TString FileName, TString NameSample, TString SystName, TString Region, TString Var);

--- a/src/ValidationUtils.h
+++ b/src/ValidationUtils.h
@@ -14,8 +14,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef ValidationUtilsDEF
-#define ValidationUtilsDEF
+#ifndef VALIDATIONUTILS_H
+#define VALIDATIONUTILS_H
 
 //Combination/trunk/Tools/CombinationGlob.h
 #include "TCanvas.h"
@@ -51,7 +51,7 @@ namespace ValidationUtils
 
   // set frame styles
   void SetFrameStyle2D( TH1* frame, Float_t scale = 1.0 );
-  
+
   void PullPlot3(XtraValues* inValsEl, XtraValues* inValsMu, const TString& outFileNamePrefix);
   void PullPlot4(XtraValues* inVals, const TString& outFileNamePrefix);
   void PullPlot5(XtraValues* inValsEl, XtraValues* inValsMu,  XtraValues* inValsEM, const TString& outFileNamePrefix);

--- a/src/toy_utils.cxx
+++ b/src/toy_utils.cxx
@@ -98,7 +98,7 @@ void CollectAndWriteHypoTestResults( const TString& infile, const TString& forma
     TString rootoutfilestub = outdir + listname;
 
     // collect p-values, store rootfile if needed
-    std::list<LimitResult> summary = CollectHypoTestResults( infile, format, interpretation, cutStr, rejectFailedPrefit ); 
+    std::list<LimitResult> summary = CollectHypoTestResults( infile, format, interpretation, cutStr, rejectFailedPrefit );
 
     // store harvest in text file
     //return WriteResultSet( summary, listname, outdir );
@@ -107,16 +107,16 @@ void CollectAndWriteHypoTestResults( const TString& infile, const TString& forma
 
 
 //________________________________________________________________________________________________
-std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TString& format, const TString& interpretation, 
-        const TString& cutStr, const bool& rejectFailedPrefit ) 
+std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TString& format, const TString& interpretation,
+        const TString& cutStr, const bool& rejectFailedPrefit )
 {
     std::list<LimitResult> limres;
-    if ( infile.IsNull() || format.IsNull() || interpretation.IsNull() ) 
+    if ( infile.IsNull() || format.IsNull() || interpretation.IsNull() )
         return limres;
 
     // collect all hypotest results in input file
     std::map<TString,TString> wsnameMap = GetMatchingWorkspaces( infile, format, interpretation, cutStr );
-    if ( wsnameMap.empty() ) 
+    if ( wsnameMap.empty() )
         return limres;
 
     // loop over hypotestresults and save results
@@ -129,7 +129,7 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
     int counter_badcovquality = 0;
     int counter_probably_bad_fit = 0;
 
-    RooStats::HypoTestInverterResult *ht = NULL; 
+    RooStats::HypoTestInverterResult *ht = NULL;
     RooFitResult *fitresult = NULL;
 
     //for (; itr!=end; ++itr) {
@@ -143,7 +143,7 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
                 << " has failed HypoTestInverterResult - cannot use result. Skip." << GEndl;
             delete ht; ht=NULL;
             continue;
-        } 
+        }
 
         //Check fit result
         TString fitresultname = TString(ht->GetName());
@@ -162,7 +162,7 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
         if (fitresult && fitresult->status()!=0) {
             ToyUtilsLogger << kWARNING << "Fit failed for point " << fitresultname.Data() << ". Result has been flagged as failed fit." << GEndl;
             ++counter_failed_status;
-            failed_status = true;   
+            failed_status = true;
         }
 
         int fitstatus = -1;
@@ -173,13 +173,13 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
         bool failed_cov = false;
         bool dodgy_cov = false;
         if (fitresult && fitresult->covQual() < 1.1) {
-            ToyUtilsLogger << kWARNING << "Fit result " << fitresultname.Data() 
+            ToyUtilsLogger << kWARNING << "Fit result " << fitresultname.Data()
                 << " has bad covariance matrix quality! Result has been flagged as failed fit." << GEndl;
             ++counter_badcovquality;
             //failed_fit = true;
             failed_cov = true;
         } else if (fitresult && fitresult->covQual() < 2.1) {
-            ToyUtilsLogger << kWARNING << "Fit result " << fitresultname.Data() 
+            ToyUtilsLogger << kWARNING << "Fit result " << fitresultname.Data()
                 << " has mediocre covariance matrix quality. Result has been flagged as failed cov matrix." << GEndl;
             ++counter_not_great_fits;
             //failed_cov = true;
@@ -202,7 +202,7 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
         // MB Keeping points for now, this also rejects bad fits.
         if (fabs(result.GetP0()-0.5) < 0.0001 && result.GetSigma0() < 0.0001){
             //counter_probably_bad_fit++;
-            ToyUtilsLogger << kINFO << "One of the base fits _may_ have failed for point (or may not): " 
+            ToyUtilsLogger << kINFO << "One of the base fits _may_ have failed for point (or may not): "
                 << fitresultname.Data() << " : " << result.GetP0() << " " << result.GetSigma0() << " Flagged as p0=0.5." << GEndl;
             //failed_fit = true;
             failed_p0half = true;
@@ -222,16 +222,16 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
         result.AddMetaData ( ParseWorkspaceID(itr.first) );
         result.AddMetaData ( failMap );
 
-        // store info from interpretation string (eg m0 and m12 value) 
-        limres.push_back(result); 
+        // store info from interpretation string (eg m0 and m12 value)
+        limres.push_back(result);
 
         if(ht){ delete ht; ht=NULL; }
         if(fitresult) { delete fitresult; fitresult=NULL; }
     }
     infile_f->Close();
-    ToyUtilsLogger << kINFO << counter_failed_status << " failed fit status and " << counter_badcovquality 
+    ToyUtilsLogger << kINFO << counter_failed_status << " failed fit status and " << counter_badcovquality
         << " fit(s) with bad covariance matrix quality were counted" << GEndl;
-    ToyUtilsLogger << kINFO << counter_probably_bad_fit << " fit(s) with a bad p-value and " << counter_not_great_fits 
+    ToyUtilsLogger << kINFO << counter_probably_bad_fit << " fit(s) with a bad p-value and " << counter_not_great_fits
         << " fit(s) with mediocre covariance matrix quality were counted" << GEndl;
     ToyUtilsLogger << kINFO << "All but the ones with mediocre covariance matrix quality were rejected from the final results list." << GEndl;
     ToyUtilsLogger << kINFO << counter_failed_fits << " failed fit(s)" << GEndl;
@@ -242,13 +242,13 @@ std::list<LimitResult> CollectHypoTestResults( const TString& infile, const TStr
 
 //________________________________________________________________________________________________
 void WriteResultSetJSON( const std::list<LimitResult>& summary, const TString& listname, const TString& outDir ){
-    if (summary.empty()) { 
+    if (summary.empty()) {
         return;
     }
 
     ToyUtilsLogger << kINFO << "Storing results of " << summary.size() << " scan points as JSON" << GEndl;
 
-    TString outdir = gSystem->pwd(); 
+    TString outdir = gSystem->pwd();
     if ( !gSystem->cd( outDir.Data() ) ) {
         ToyUtilsLogger << kERROR << "output dir <" << outDir << "> does not exist. Return." << GEndl;
         return;
@@ -264,8 +264,8 @@ void WriteResultSetJSON( const std::list<LimitResult>& summary, const TString& l
     outfile << outdir.Data() << listname.Data() << "_harvest_list.json";
 
     JSON limresJSON = JSON::Array();
-    for(auto const &l: summary) { 
-        limresJSON.asVector().push_back( l.GetJSONData()); 
+    for(auto const &l: summary) {
+        limresJSON.asVector().push_back( l.GetJSONData());
     }
 
     // write out files
@@ -289,7 +289,7 @@ void WriteResultSet( const std::list<LimitResult>& summary, const TString& listn
 
     ToyUtilsLogger << kINFO << "Storing results of " << summary.size() << " scan points." << GEndl;
 
-    TString outdir = gSystem->pwd(); 
+    TString outdir = gSystem->pwd();
     if ( !gSystem->cd( outDir.Data() ) ) {
         ToyUtilsLogger << kERROR << "output dir <" << outDir << "> does not exist. Return." << GEndl;
         return;
@@ -343,7 +343,7 @@ void WriteResultSet( const std::list<LimitResult>& summary, const TString& listn
     writetree   += "  file->Close();\n";
     writetree   += "}\n";
 
-    mymain  = "\nvoid summary_harvest_tree_description() {\n"; 
+    mymain  = "\nvoid summary_harvest_tree_description() {\n";
     mymain += "  TTree* tree = harvesttree();\n";
     mymain += "  gDirectory->Add(tree);\n";
     mymain += "}\n";
@@ -447,7 +447,7 @@ void CollectAndWriteResultSet( const TString& infile, const TString& format, con
     TString rootoutfilestub = outdir + listname;
 
     // collect p-values, store rootfile if needed
-    std::list<LimitResult> summary = CollectLimitResults( infile, format, interpretation, cutStr, mode, n_toys, do_ul ); 
+    std::list<LimitResult> summary = CollectLimitResults( infile, format, interpretation, cutStr, mode, n_toys, do_ul );
 
     // store harvest in text file
     //return WriteResultSet( summary, listname, outdir );
@@ -458,12 +458,12 @@ void CollectAndWriteResultSet( const TString& infile, const TString& format, con
 //________________________________________________________________________________________________
 std::list<LimitResult> CollectLimitResults( const TString& infile, const TString& format, const TString& interpretation, const TString& cutStr, const int& mode, const int& n_toys, const int& do_ul) {
     std::list<LimitResult> limres;
-    if ( infile.IsNull() || format.IsNull() || interpretation.IsNull() ) 
+    if ( infile.IsNull() || format.IsNull() || interpretation.IsNull() )
         return limres;
 
     // classify all workspaces in input files
     std::map<TString,TString> wsnameMap = GetMatchingWorkspaces( infile, format, interpretation, cutStr );
-    if ( wsnameMap.empty() ) 
+    if ( wsnameMap.empty() )
         return limres;
 
     // loop over workspaces and print results
@@ -472,7 +472,7 @@ std::list<LimitResult> CollectLimitResults( const TString& infile, const TString
 
     //for (; itr!=end; ++itr) {
     for (const auto &itr : wsnameMap) {
-        RooWorkspace* w = GetWorkspaceFromFile( infile, itr.second );
+        RooWorkspace* w = Util::GetWorkspaceFromFile( infile, itr.second );
         LimitResult result = get_Pvalue( w, mode, n_toys, do_ul, itr.first );
         limres.push_back(result);
         delete w;

--- a/src/toy_utils.h
+++ b/src/toy_utils.h
@@ -15,8 +15,8 @@
  * LICENSE.                                                                       *
  **********************************************************************************/
 
-#ifndef toy_utilsDEF
-#define toy_utilsDEF 
+#ifndef TOYUTILS_H
+#define TOYUTILS_H
 
 #include "TString.h"
 #include "LimitResult.h"
@@ -35,8 +35,8 @@ LimitResult get_Pvalue( RooWorkspace* w, const int& mode=0, const int& n_toys=10
 std::list<LimitResult> CollectLimitResults( const TString& infile, const TString& format, const TString& interpretation, const TString& cutStr="1", const int& mode=0, const int& n_toys=10000, const int& do_ul=1 );
 void WriteResultSetJSON(const std::list<LimitResult>& summary, const TString& listname, const TString& outDir="./");
 void WriteResultSet(const std::list<LimitResult>& summary, const TString& listname, const TString& outDir="./");
-void CollectAndWriteResultSet( const TString& infile, const TString& format, const TString& interpretation, const TString& cutStr="1", 
-        const int& mode=0, const int& par1=100000 /*nexp*/, const int& par2=0 /*nobssigma*/, const int& par3=0, 
+void CollectAndWriteResultSet( const TString& infile, const TString& format, const TString& interpretation, const TString& cutStr="1",
+        const int& mode=0, const int& par1=100000 /*nexp*/, const int& par2=0 /*nobssigma*/, const int& par3=0,
         const TString& outDir="./", const TString& fileprefix="" );
 
 // same, but collect and convert hypotest results


### PR DESCRIPTION
- Adds include guard to DrawUtils.h
- Removes GetWorkspaceFromFile from CombineWorkSpaces
- Fixes namespace weirdness in DrawUtils
- These changes make it possible to precompile the headers, which can
  speed up incremental builds, and use unity build (aka jumbo build),
  which can help the compiler do further optimizations and reduce
  compile time.
- Conforms include guards to single style