### PR TITLE
Temporary workaround for crash with ROOT 6.28

### DIFF
--- a/src/HypoTestTool.cxx
+++ b/src/HypoTestTool.cxx
@@ -546,7 +546,7 @@ RooStats::HypoTestTool::SetupHypoTestCalculator(RooWorkspace * w, bool doUL,
         RooCmdArg _Hesse(Hesse(false));
         RooCmdArg _Minimizer(Minimizer(mMinimizerType.c_str(), "Migrad"));
         RooCmdArg _Offset(Offset(true));
-        RooCmdArg _AsymptoticError(AsymptoticError(true));
+        RooCmdArg _AsymptoticError(AsymptoticError(false));
         RooCmdArg _Strategy_speed(Strategy(0));
         RooCmdArg _Strategy_default(Strategy(1));
         RooCmdArg _Verbose(Verbose(verbose));


### PR DESCRIPTION
Disabling AsymptoticError(false) in hypotesttool to workaround a crash with toys.  Thanks to Nikolai Fomin for figuring this out.