### PR TITLE
V1.2.1 UserSystematic fix [BUG]

### DIFF
--- a/python/configManager.py
+++ b/python/configManager.py
@@ -1059,7 +1059,7 @@ class ConfigManager:
 
                     # Do not fall back if the sample has no input files defined!
                     forceNoFallback = len(sam.input_files) == 0
-                    syst.PrepareGlobalNormalization(normString, self, chan, sam, forceNoFallBack)
+                    syst.PrepareGlobalNormalization(normString, self, chan, sam, forceNoFallback)
                     sam.addHistoSys(syst.name, nomName, highName, lowName, False, True, False, False, sam.name, normString)
 
         # post-processing 2: swapping of overall systematics for specified channel by systematics from other channel

--- a/python/prepareHistos.py
+++ b/python/prepareHistos.py
@@ -86,7 +86,7 @@ class PrepareHistos:
         Initialise the preparation object
 
         @param useCache Read out histograms from the cache file rather than trees
-        @param useCacheToTreeFallBack If reading from histograms, fall back to trees in case they are not found
+        @param useCacheToTreeFallback If reading from histograms, fall back to trees in case they are not found
         """
         from configManager import configMgr
 
@@ -388,7 +388,7 @@ class PrepareHistos:
         @param binHighY Higher edge of right Y bin
         @param useOverflow Use the overflow bins or not?
         @param useUnderflow Use the underflow bins or not ?
-        @param forceNoFallBack If true, never use the fallback mechanism for this histogram
+        @param forceNoFallback If true, never use the fallback mechanism for this histogram
 
         @retval The constructed histogram
         """

--- a/python/systematic.py
+++ b/python/systematic.py
@@ -553,7 +553,7 @@ class UserSystematic(SystematicBase):
                     abstract.hists[lowhighName] = histMgr.buildUserHistoSysFromHist(lowhighName, self.low, abstract.hists[nomName])
         return
 
-    def PrepareGlobalNormalization(self,normString,abstract,chan,sam,forceNoFallBack=False):
+    def PrepareGlobalNormalization(self,normString,abstract,chan,sam,forceNoFallback=False):
 
         for lowhigh in ["Nom_",self.name+"High_",self.name+"Low_"]:
             histName = f"h{sam.name}{lowhigh}{normString}Norm"

--- a/python/systematic.py
+++ b/python/systematic.py
@@ -563,7 +563,8 @@ class UserSystematic(SystematicBase):
                     if not abstract.readFromTree:
                         abstract.hists[histName] = None
                         abstract.prepare.addHisto(histName, forceNoFallback=forceNoFallback)
-                    else:
+
+                    if abstract.hists[histName] is None:
                         abstract.hists[histName] = TH1D(histName, histName, 1, 0.5, 1.5)
                         totNorm=0.0
                         for normReg in sam.normRegions:


### PR DESCRIPTION
Hi!

This PR fixes two bugs:

- The first bug was introduced in #150, wherein python/configManager.py, line 1062, the wrong casing was used (forceNoFallBack instead of forceNoFallback). I don't know how this got in the commit, because it worked when I tested it; I must have accidentally undid the correction for the typo before committing. Sorry!
- The second bug is a long-standing bug where the normalized histograms for userNormHistoSys systematics are not created if HistFitter is not run with "-t". This is a problem if the workspace is built using a backup cache file.

I strongly suggest merging these changes as soon as possible and creating a v1.2.2 version.

To catch future bugs in the histogram creation, it would be good to add one instance of every possible systematic type to test_fullchain.py. And then try to rerun HistFitter without "-t" using the previous cache as the backup cache. I'll implement that tomorrow, and send another PR.