### PR TITLE
Added tests for all systematic types, fixed one remaining bug in userNormHistoSys [BUG]

### DIFF
--- a/python/systematic.py
+++ b/python/systematic.py
@@ -564,7 +564,7 @@ class UserSystematic(SystematicBase):
                         abstract.hists[histName] = None
                         abstract.prepare.addHisto(histName, forceNoFallback=forceNoFallback)
 
-                    if abstract.hists[histName] is None:
+                    if abstract.readFromTree or abstract.hists[histName] is None:
                         abstract.hists[histName] = TH1D(histName, histName, 1, 0.5, 1.5)
                         totNorm=0.0
                         for normReg in sam.normRegions:

--- a/test/scripts/config_for_pytest.py
+++ b/test/scripts/config_for_pytest.py
@@ -19,6 +19,7 @@ gROOT.SetBatch(True)
 includeOverflowBin = True
 useStat    = True
 useToys = False
+manualBackupCache = None
 
 
 input_file = "test_tree.root"
@@ -27,12 +28,14 @@ nominal_tree_name = "_NoSys"
 
 parser = argparse.ArgumentParser(description="HistFitter Testing")
 parser.add_argument('--useToys', action="store_true")
+parser.add_argument('--manualBackupCache')
 
 
 if configMgr.userArg != "":
     args = parser.parse_args( configMgr.userArg.split() )
 
     useToys    = args.useToys
+    manualBackupCache = args.manualBackupCache
 
 # name for analysis, used in a lot of directory and filenames
 anaName = "hf_test"
@@ -64,9 +67,14 @@ try: os.mkdir('results/'+configMgr.analysisName )
 except: pass
 
 ##############
-configMgr.useCacheToTreeFallback = True
 configMgr.useHistBackupCacheFile = True # enable the use of an alternate data file
-configMgr.histBackupCacheFile =  "data/" + analysisNameBase + "/histCache.root" # the data file of your previous fit (= the backup cache file)
+if manualBackupCache is None:
+    configMgr.useCacheToTreeFallback = True
+    configMgr.histBackupCacheFile =  "data/" + analysisNameBase + "/histCache.root"
+else:
+    configMgr.useCacheToTreeFallback = False
+    configMgr.histBackupCacheFile =  manualBackupCache
+    configMgr.forceNorm = False # If we don't disable this, HF tries to build the Norm histograms from the trees anyways, even if useCacheToTreeFallback is set to Fale
 
 configMgr.outputFileName = "results/" + configMgr.analysisName  + "/Output.root"
 configMgr.histCacheFile = "data/" + analysisNameBase + "/histCache.root"
@@ -109,6 +117,7 @@ bkg2Sample.setSuffixTreeName("_nom")
 bkg2Sample.addInputs( [input_file] )
 bkg2Sample.setNormByTheory(False)
 bkg2Sample.setNormFactor("mu_bkg",1.,0.,10.)
+bkg2Sample.setNormRegions([('CR', 'm')])
 
 
 dataSample = Sample("data", kBlack)
@@ -121,12 +130,24 @@ sigSample.setNormByTheory(True)
 sigSample.setNormFactor("mu_SIG",1.,0,100)
 
 ######### Systematics
-bkg1Sample.addSystematic( Systematic('user_overallSys', '', 1.05, 0.95, 'user', 'overallSys') )
-bkg1Sample.addSystematic( Systematic('weight_sys', configMgr.weights, ['weight','sys_weight'], ['weight','1./sys_weight'], 'weight', 'histoSys') )
+bkg1Sample.addSystematic( Systematic('weight_histoSys', configMgr.weights, ['weight','sys_weight1'], ['weight','1./sys_weight1'], 'weight', 'histoSys') )
+bkg1Sample.addSystematic( Systematic('weight_overallSys', configMgr.weights, ['weight','sys_weight2'], ['weight','1./sys_weight2'], 'weight', 'overallSys') )
+bkg1Sample.addSystematic( Systematic('weight_overallHistoSys', configMgr.weights, ['weight','sys_weight3'], ['weight','1./sys_weight3'], 'weight', 'overallHistoSys') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysOneSide', configMgr.weights, ['weight', 'sys_weight4'], ['weight', 'sys_weight4'], 'weight', 'histoSysOneSide') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysOneSideSym', configMgr.weights, ['weight', 'sys_weight5'], ['weight', 'sys_weight5'], 'weight', 'histoSysOneSideSym') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight6'], ['weight', '1/sys_weight6'], 'weight', 'histoSysEnvelopeSym') )
+bkg1Sample.addSystematic( Systematic('user_overallSys', '', 1.05, 0.95, 'user', 'userOverallSys') )
+bkg1Sample.addSystematic( Systematic('user_histoSys', '', 1.05, 0.95, 'user', 'userHistoSys') )
 
-bkg2Sample.addSystematic( Systematic('tree_sys', '', '_sys', '_sys', 'tree', 'normHistoSysOneSideSym') )
+bkg2Sample.addSystematic( Systematic('weight_overallNormSys', configMgr.weights, ['weight', 'sys_weight1'], ['weight', '1./sys_weight1'], 'weight', 'overallNormSys') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSys', configMgr.weights, ['weight', 'sys_weight2'], ['weight', '1./sys_weight2'], 'weight', 'normHistoSys') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSysOneSide', configMgr.weights, ['weight', 'sys_weight3'], ['weight', 'sys_weight3'], 'weight', 'normHistoSysOneSide') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight4'], ['weight', '1./sys_weight4'], 'weight', 'normHistoSysEnvelopeSym') )
+bkg2Sample.addSystematic( Systematic('weight_overallNormHistoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight5'], ['weight', '1./sys_weight5'], 'weight', 'overallNormHistoSysEnvelopeSym') )
+bkg2Sample.addSystematic( Systematic('tree_normHistoSysOneSideSym', '', '_sys', '_sys', 'tree', 'normHistoSysOneSideSym') )
+bkg2Sample.addSystematic( Systematic('user_normHistoSys', '', 1.05, 0.95, 'user', 'userNormHistoSys') )
 
-sigSample.addSystematic( Systematic('flat_sys', '', 1.10, 0.90, 'user', 'overallSys') )
+sigSample.addSystematic( Systematic('flat_sys', '', 1.10, 0.90, 'user', 'userOverallSys') )
 
 ########## Fit Config Base ##########
 bkgName = "BkgOnly"

--- a/test/scripts/genTree.C
+++ b/test/scripts/genTree.C
@@ -17,7 +17,12 @@ void genTree(){
 
     double m = 0; //{50,100,150,200}
     double weight = 1;
-    double sys_weight = 1;
+    double sys_weight1 = 1;
+    double sys_weight2 = 1;
+    double sys_weight3 = 1;
+    double sys_weight4 = 1;
+    double sys_weight5 = 1;
+    double sys_weight6 = 1;
 
     // Data tree
     TTree *data_tree = new TTree("data","data");
@@ -33,12 +38,23 @@ void genTree(){
     TTree *bkg1_tree = new TTree("bkg1_nom","bkg1_nom");
     bkg1_tree->Branch("m", &m, "m/D");
     bkg1_tree->Branch("weight", &weight, "weight/D");
-    bkg1_tree->Branch("sys_weight", &sys_weight, "sys_weight/D");
+    bkg1_tree->Branch("sys_weight1", &sys_weight1, "sys_weight1/D");
+    bkg1_tree->Branch("sys_weight2", &sys_weight2, "sys_weight2/D");
+    bkg1_tree->Branch("sys_weight3", &sys_weight3, "sys_weight3/D");
+    bkg1_tree->Branch("sys_weight4", &sys_weight4, "sys_weight4/D");
+    bkg1_tree->Branch("sys_weight5", &sys_weight5, "sys_weight5/D");
+    bkg1_tree->Branch("sys_weight6", &sys_weight6, "sys_weight6/D");
 
     // Bkg2 tree (falling)
     TTree *bkg2_nom_tree = new TTree("bkg2_nom","bkg2_nom");
     bkg2_nom_tree->Branch("m", &m, "m/D");
     bkg2_nom_tree->Branch("weight", &weight, "weight/D");
+    bkg2_nom_tree->Branch("sys_weight1", &sys_weight1, "sys_weight1/D");
+    bkg2_nom_tree->Branch("sys_weight2", &sys_weight2, "sys_weight2/D");
+    bkg2_nom_tree->Branch("sys_weight3", &sys_weight3, "sys_weight3/D");
+    bkg2_nom_tree->Branch("sys_weight4", &sys_weight4, "sys_weight4/D");
+    bkg2_nom_tree->Branch("sys_weight5", &sys_weight5, "sys_weight5/D");
+    bkg2_nom_tree->Branch("sys_weight6", &sys_weight6, "sys_weight6/D");
 
     TTree *bkg2_sys_tree = new TTree("bkg2_sys","bkg2_sys");
     bkg2_sys_tree->Branch("m", &m, "m/D");
@@ -75,7 +91,12 @@ void genTree(){
     {
         weight = norm;
         m = rnd.Uniform(150)+50.;
-        sys_weight = 1.03 + .05*(m-50.)/150.;
+        sys_weight1 = 1.03 + .05*(m-50.)/150.;
+        sys_weight2 = 1.02 + .01*(m-50.)/150.;
+        sys_weight3 = 1.01 + .02*(m-50.)/150.;
+        sys_weight4 = 1.02 + .03*(m-50.)/150.;
+        sys_weight5 = 1.03 + .04*(m-50.)/150.;
+        sys_weight6 = 1.01 + .06*(m-50.)/150.;
         bkg1_tree->Fill();
     }
 
@@ -84,6 +105,13 @@ void genTree(){
     { 
         weight = 1/3.;
         m = 75.;
+        float r = rnd.Uniform(30) + 75.;
+        sys_weight1 = 1.03 + .05*(m-75.)/30.;
+        sys_weight2 = 1.02 + .01*(m-75.)/30.;
+        sys_weight3 = 1.01 + .02*(m-75.)/30.;
+        sys_weight4 = 1.02 + .03*(m-75.)/30.;
+        sys_weight5 = 1.03 + .04*(m-75.)/30.;
+        sys_weight6 = 1.01 + .06*(m-75.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }
@@ -91,13 +119,27 @@ void genTree(){
     { 
         weight = 1/3.;
         m = 125.;
+        float r = rnd.Uniform(30) + 125.;
+        sys_weight1 = 1.03 + .05*(m-125.)/30.;
+        sys_weight2 = 1.02 + .01*(m-125.)/30.;
+        sys_weight3 = 1.01 + .02*(m-125.)/30.;
+        sys_weight4 = 1.02 + .03*(m-125.)/30.;
+        sys_weight5 = 1.03 + .04*(m-125.)/30.;
+        sys_weight6 = 1.01 + .06*(m-125.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }
     for (int i=0; i<3*(10-9); i++)
     { 
         weight = 1/3.;
-        m = 175.;   
+        m = 175.;
+        float r = rnd.Uniform(30) + 175.;
+        sys_weight1 = 1.03 + .05*(m-175.)/30.;
+        sys_weight2 = 1.02 + .01*(m-175.)/30.;
+        sys_weight3 = 1.01 + .02*(m-175.)/30.;
+        sys_weight4 = 1.02 + .03*(m-175.)/30.;
+        sys_weight5 = 1.03 + .04*(m-175.)/30.;
+        sys_weight6 = 1.01 + .06*(m-175.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }

--- a/test/test_fullchain.py
+++ b/test/test_fullchain.py
@@ -13,6 +13,123 @@ for k in f.GetListOfKeys():
     print(f"{k.GetName()}: {val},")
 """
 
+bkg_only_test_values = {
+    'hbkg1Nom_CR_obs_m': 3.2219999999999756, 
+    'hbkg1Nom_SR_obs_m': 5.777999999999959, 
+    'hbkg1user_histoSysHigh_CR_obs_m': 3.3830999999999745, 
+    'hbkg1user_histoSysHigh_SR_obs_m': 6.066899999999957, 
+    'hbkg1user_histoSysLow_CR_obs_m': 3.0608999999999766, 
+    'hbkg1user_histoSysLow_SR_obs_m': 5.489099999999961, 
+    'hbkg1user_overallSysHigh_CR_obs_m': 3.3830999999999745, 
+    'hbkg1user_overallSysHigh_SR_obs_m': 6.066899999999957, 
+    'hbkg1user_overallSysLow_CR_obs_m': 3.0608999999999766, 
+    'hbkg1user_overallSysLow_SR_obs_m': 5.489099999999961, 
+    'hbkg1weight_histoSysEnvelopeSymHigh_CR_obs_m': 3.2846586611647037, 
+    'hbkg1weight_histoSysEnvelopeSymHigh_SR_obs_m': 6.070510527144715, 
+    'hbkg1weight_histoSysEnvelopeSymLow_CR_obs_m': 3.1593413388352474, 
+    'hbkg1weight_histoSysEnvelopeSymLow_SR_obs_m': 5.485489472855202, 
+    'hbkg1weight_histoSysHigh_CR_obs_m': 3.3440255509705903, 
+    'hbkg1weight_histoSysHigh_SR_obs_m': 6.146948772620593, 
+    'hbkg1weight_histoSysLow_CR_obs_m': 3.1044935654749426, 
+    'hbkg1weight_histoSysLow_SR_obs_m': 5.43164435395858, 
+    'hbkg1weight_histoSysOneSideHigh_CR_obs_m': 3.301659330582352, 
+    'hbkg1weight_histoSysOneSideHigh_SR_obs_m': 6.010925263572357, 
+    'hbkg1weight_histoSysOneSideLow_CR_obs_m': 3.301659330582352, 
+    'hbkg1weight_histoSysOneSideLow_SR_obs_m': 6.010925263572357, 
+    'hbkg1weight_histoSysOneSideSymHigh_CR_obs_m': 3.3389524407764695, 
+    'hbkg1weight_histoSysOneSideSymHigh_SR_obs_m': 6.107827018096476, 
+    'hbkg1weight_histoSysOneSideSymLow_CR_obs_m': 3.1050475592234816, 
+    'hbkg1weight_histoSysOneSideSymLow_SR_obs_m': 5.448172981903442, 
+    'hbkg1weight_overallHistoSysHigh_CR_obs_m': 3.264366220388233, 
+    'hbkg1weight_overallHistoSysHigh_CR_obs_mNorm': 3.221999999999975, 
+    'hbkg1weight_overallHistoSysHigh_SR_obs_m': 5.914023509048238, 
+    'hbkg1weight_overallHistoSysHigh_SR_obs_mNorm': 5.77799999999996, 
+    'hbkg1weight_overallHistoSysLow_CR_obs_m': 3.1801950365209026, 
+    'hbkg1weight_overallHistoSysLow_CR_obs_mNorm': 3.221999999999975, 
+    'hbkg1weight_overallHistoSysLow_SR_obs_m': 5.645185558107728, 
+    'hbkg1weight_overallHistoSysLow_SR_obs_mNorm': 5.777999999999958, 
+    'hbkg1weight_overallSysHigh_CR_obs_m': 3.2915131101941175, 
+    'hbkg1weight_overallSysHigh_SR_obs_m': 5.9326817545241175, 
+    'hbkg1weight_overallSysLow_CR_obs_m': 3.1539577128203415, 
+    'hbkg1weight_overallSysLow_SR_obs_m': 5.627371169475674, 
+    'hbkg2Nom_CRNorm': 90.99999999999979, 
+    'hbkg2Nom_CR_obs_m': 90.99999999999979, 
+    'hbkg2Nom_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CRNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CR_obs_m': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CRNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CR_obs_m': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymLow_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2user_normHistoSysHigh_CRNorm': 95.54999999999978, 
+    'hbkg2user_normHistoSysHigh_CR_obs_m': 95.54999999999978, 
+    'hbkg2user_normHistoSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2user_normHistoSysHigh_SR_obs_m': 12.600000000000003, 
+    'hbkg2user_normHistoSysHigh_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2user_normHistoSysLow_CRNorm': 86.44999999999979, 
+    'hbkg2user_normHistoSysLow_CR_obs_m': 86.44999999999979, 
+    'hbkg2user_normHistoSysLow_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2user_normHistoSysLow_SR_obs_m': 11.4, 
+    'hbkg2user_normHistoSysLow_SR_obs_mNorm': 12.0, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CRNorm': 92.82000000000059, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CR_obs_m': 92.82000000000059, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_SR_obs_m': 12.239999999999997, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_SR_obs_mNorm': 11.999999999999892, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CRNorm': 89.2156862745101, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CR_obs_m': 89.17999999999898, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CR_obs_mNorm': 90.96359999999845, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_SR_obs_m': 11.760000000000007, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_SR_obs_mNorm': 11.995199999999938, 
+    'hbkg2weight_normHistoSysHigh_CRNorm': 92.82000000000059, 
+    'hbkg2weight_normHistoSysHigh_CR_obs_m': 92.82000000000059, 
+    'hbkg2weight_normHistoSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysHigh_SR_obs_m': 12.239999999999997, 
+    'hbkg2weight_normHistoSysHigh_SR_obs_mNorm': 11.999999999999892, 
+    'hbkg2weight_normHistoSysLow_CRNorm': 89.2156862745101, 
+    'hbkg2weight_normHistoSysLow_CR_obs_m': 89.2156862745101, 
+    'hbkg2weight_normHistoSysLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysLow_SR_obs_m': 11.764705882352942, 
+    'hbkg2weight_normHistoSysLow_SR_obs_mNorm': 11.999999999999932, 
+    'hbkg2weight_normHistoSysOneSideHigh_CRNorm': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideHigh_CR_obs_m': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideHigh_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2weight_normHistoSysOneSideHigh_SR_obs_m': 12.119999999999997, 
+    'hbkg2weight_normHistoSysOneSideHigh_SR_obs_mNorm': 11.999999999999913, 
+    'hbkg2weight_normHistoSysOneSideLow_CRNorm': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideLow_CR_obs_m': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideLow_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2weight_normHistoSysOneSideLow_SR_obs_m': 12.119999999999997, 
+    'hbkg2weight_normHistoSysOneSideLow_SR_obs_mNorm': 11.999999999999913, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CRNorm': 93.73000000000009, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CR_obs_m': 93.73000000000009, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_SR_obs_m': 12.360000000000007, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_SR_obs_mNorm': 12.000000000000004, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CRNorm': 88.34951456310662, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CR_obs_m': 88.26999999999948, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_SR_obs_m': 11.639999999999997, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_SR_obs_mNorm': 12.0, 
+    'hbkg2weight_overallNormSysHigh_CRNorm': 93.73000000000009, 
+    'hbkg2weight_overallNormSysHigh_CR_obs_m': 93.73000000000009, 
+    'hbkg2weight_overallNormSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormSysHigh_SR_obs_m': 12.360000000000007, 
+    'hbkg2weight_overallNormSysHigh_SR_obs_mNorm': 12.000000000000004, 
+    'hbkg2weight_overallNormSysLow_CRNorm': 88.34951456310662, 
+    'hbkg2weight_overallNormSysLow_CR_obs_m': 88.34951456310662, 
+    'hbkg2weight_overallNormSysLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormSysLow_SR_obs_m': 11.650485436893199, 
+    'hbkg2weight_overallNormSysLow_SR_obs_mNorm': 12.0, 
+    'hdata_CR_obs_m': 105.0, 
+    'hdata_SR_obs_m': 21.0
+}
+
+
 def test_treeToHist(script_runner):
 
     # Make input TTree if needed
@@ -28,35 +145,38 @@ def test_treeToHist(script_runner):
     assert os.path.isfile("data/hf_test/histCache.root") # histcache generated
 
     # values from snippet above
-    test_values = {
-        "hbkg1Nom_CR_obs_m": 3.2219999999999756,
-        "hbkg1Nom_SR_obs_m": 5.777999999999959,
-        "hbkg1user_overallSysHigh_CR_obs_m": 3.3830999999999745,
-        "hbkg1user_overallSysHigh_SR_obs_m": 6.066899999999957,
-        "hbkg1user_overallSysLow_CR_obs_m": 3.0608999999999766,
-        "hbkg1user_overallSysLow_SR_obs_m": 5.489099999999961,
-        "hbkg1weight_sysHigh_CR_obs_m": 3.3440255509705903,
-        "hbkg1weight_sysHigh_SR_obs_m": 6.146948772620593,
-        "hbkg1weight_sysLow_CR_obs_m": 3.1044935654749426,
-        "hbkg1weight_sysLow_SR_obs_m": 5.43164435395858,
-        "hbkg2Nom_CR_obs_m": 90.99999999999979,
-        "hbkg2Nom_SR_obs_m": 12.000000000000002,
-        "hbkg2tree_sysHigh_CR_obs_m": 90.99999999999979,
-        "hbkg2tree_sysHigh_SR_obs_m": 12.000000000000002,
-        "hbkg2tree_sysLow_CR_obs_m": 90.99999999999979,
-        "hbkg2tree_sysLow_SR_obs_m": 12.000000000000002,
-        "hdata_CR_obs_m": 105.0,
-        "hdata_SR_obs_m": 21.0
-    }
-
     hc = ROOT.TFile("data/hf_test/histCache.root")
     for k in hc.GetListOfKeys():
         name = k.GetName()
         val = hc.Get(name).Integral()
 
-        assert math.isclose(test_values[name], val) # histogram integral matches test values
+        assert math.isclose(bkg_only_test_values[name], val) # histogram integral matches test values
 
 
+def test_backupCache(script_runner):
+    command = 'mv ${HISTFITTER}/test/data/hf_test/histCache.root ${HISTFITTER}/test/test_backup_cache.root'
+    (ret, outRaw, errRaw) = script_runner(command)
+
+    hc = ROOT.TFile.Open('test_backup_cache.root', 'UPDATE')
+    for k in hc.GetListOfKeys():
+        name = k.GetName()
+        if name.endswith('mNorm'):
+            hc.Delete(f'{name};*')
+    hc.Close()
+
+    command = "HistFitter.py -w -u='--manualBackupCache ${HISTFITTER}/test/test_backup_cache.root' ${HISTFITTER}/test/scripts/config_for_pytest.py"
+    (ret,outRaw,errRaw) = script_runner(command)
+    assert ret.returncode == 0
+
+    assert os.path.isfile("data/hf_test/histCache.root") # histcache generated
+
+    # values from snippet above
+    hc = ROOT.TFile("data/hf_test/histCache.root")
+    for k in hc.GetListOfKeys():
+        name = k.GetName()
+        val = hc.Get(name).Integral()
+
+        assert math.isclose(bkg_only_test_values[name], val) # histogram integral matches test values
 
 def test_bkgFit(script_runner):
 
@@ -135,7 +255,7 @@ def test_sigExclusionAll(script_runner):
     with open('sysTable.tex') as f:
         contents = f.read()
         assert "Total background expectation             &  $5.7" in contents # bkg 1 yield
-        assert "Total background systematic               & $\\pm 0.7" in contents # bkg 1 sys
+        assert "Total background systematic               & $\\pm 0.9" in contents # bkg 1 sys
         
 
     # Exclusion Asymptotics
@@ -190,4 +310,4 @@ def test_discoveryAll(script_runner):
 
     with open('ulTable.tex') as f:
         contents = f.read()
-        assert 'SR\\_disc    & $0.75$ &  $7.5$ & $ { 5.6 }^{ +2.9 }_{ -1.8 }$ & $0.75$ & $ 0.21$~$(0.82)$' in contents # UL table
+        assert 'SR\\_disc    & $0.75$ &  $7.5$ & $ { 5.6 }^{ +3.0 }_{ -1.8 }$ & $0.75$ & $ 0.21$~$(0.81)$' in contents # UL table

--- a/test/test_fullchain.py
+++ b/test/test_fullchain.py
@@ -154,7 +154,7 @@ def test_treeToHist(script_runner):
 
 
 def test_backupCache(script_runner):
-    command = 'mv ${HISTFITTER}/test/data/hf_test/histCache.root ${HISTFITTER}/test/test_backup_cache.root'
+    command = 'mv data/hf_test/histCache.root test_backup_cache.root'
     (ret, outRaw, errRaw) = script_runner(command)
 
     hc = ROOT.TFile.Open('test_backup_cache.root', 'UPDATE')
@@ -164,7 +164,7 @@ def test_backupCache(script_runner):
             hc.Delete(f'{name};*')
     hc.Close()
 
-    command = "HistFitter.py -w -u='--manualBackupCache ${HISTFITTER}/test/test_backup_cache.root' ${HISTFITTER}/test/scripts/config_for_pytest.py"
+    command = "HistFitter.py -w -u='--manualBackupCache test_backup_cache.root' ${HISTFITTER}/test/scripts/config_for_pytest.py"
     (ret,outRaw,errRaw) = script_runner(command)
     assert ret.returncode == 0
 


### PR DESCRIPTION
As mentioned in #157, given that the histogram production in HistFitter from both trees and backup cache files (producing normalized systematic histograms) is done in multiple steps, across many different methods, classes, and files, having a test for all systematic types is a good idea to catch any old-standing bug (like the second change mentioned in #157), or new edge-case bugs introduced while updating the code (like the first change in #157, and the third item mentioned in this MR accidentally introduced in #157 while fixing the old-standing bug).

This MR includes:
- Tests for producing histograms for all systematic types (both normalized and non-normalized systematics)
- A test of workspace creating when running on a backup cache file produced externally, checking that all the normalized systematic histograms are produced correctly (if one was missing, a crash would happen, like the very old bug mentioned in #157 when using "userNormHistoSys")
- A bugfix for "userNormHistoSys" normalized histogram creation when running on trees (detected by the new tests)

Unfortunately, due to the last bug mentioned here, I think a new v1.2.3 is required, but with these additional tests, it shouldn't happen again.