### PR TITLE
Multiple updates/bugfixes to the HistFitter plotting code

### DIFF
--- a/python/channel.py
+++ b/python/channel.py
@@ -97,8 +97,8 @@ class Channel:
         self.ATLASLabelText = None
         self.showLumi = None
         self.lumi = None
-        self.lumiX = None
-        self.lumiY = None
+        self.lumiX = 0.0
+        self.lumiY = 0.775
         self.xErrorSize = None
         self.integerStyle = None
         self.regionLabelX = None

--- a/python/configManager.py
+++ b/python/configManager.py
@@ -97,6 +97,7 @@ class ConfigManager:
         self.inputLumi = None # Luminosity of input histograms
         self.outputLumi = None # Output luminosity
         self.lumiUnits = 1.0 # 1=fb-1, 1000=pb-1, etc.
+        self.energy = '13.6 TeV' # center-of-mass energy, to be used in plots
         self.nTOYs =- 1 #<=0 means to use real data
         self.nCPUs = 1 # number of CPUs used for toy simulation
         self.calculatorType = 0 # frequentist calculator
@@ -600,6 +601,7 @@ class ConfigManager:
                      if c.lumi is None:
                          style.setLumi(self.outputLumi)
                      else: style.setLumi(c.lumi)
+                     style.setEnergy(self.energy)
                  if not c.lumiX is None:
                      style.setLumiX(c.lumiX)
                  if not c.lumiY is None:

--- a/python/configManager.py
+++ b/python/configManager.py
@@ -141,6 +141,9 @@ class ConfigManager:
         self.includeOverallSys = True # Boolean to chose if HistoSys should also have OverallSys
         self.readFromTree = False # Boolean to chose if reading histograms from tree will also write to file
         self.plotHistos = None # Boolean to chose to plot out the histograms
+        self.plotStacked = True # Boolean to choose to do stacked before/after plots, or just individual histograms
+        self.storeSinglePlotFiles = True # Boolean to choose to store single files for each before/after plot
+        self.storeMergedPlotFile = False # Boolean to choose to store a central file for all before/after plots
         self.plotRatio="ratio" #Pass to cppMgr to configure drawing options: "ratio", "pull", "none"
         self.removeEmptyBins = False # Boolean to chose to remove empty bins from data histogram on plot
         self.executeHistFactory = True # Boolean to chose to execute HistFactory

--- a/python/systematic.py
+++ b/python/systematic.py
@@ -564,7 +564,7 @@ class UserSystematic(SystematicBase):
                         abstract.hists[histName] = None
                         abstract.prepare.addHisto(histName, forceNoFallback=forceNoFallback)
 
-                    if abstract.hists[histName] is None:
+                    if abstract.readFromTree or abstract.hists[histName] is None:
                         abstract.hists[histName] = TH1D(histName, histName, 1, 0.5, 1.5)
                         totNorm=0.0
                         for normReg in sam.normRegions:

--- a/scripts/HistFitter.py
+++ b/scripts/HistFitter.py
@@ -33,7 +33,7 @@ import sys
 from logger import Logger
 log = Logger('HistFitter')
 
-def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation):
+def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawStackPlots, storeSingleFiles, storeMergedFile, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation):
     """ 
     function call to top-level C++ side function Util.GenerateFitAndPlot()
 
@@ -41,6 +41,9 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawCorrelat
     @param anaName Analysis name defined in config file, mainly used for output file/dir naming
     @param drawBeforeFit Boolean deciding whether before-fit plots are produced
     @param drawAfterFit Boolean deciding whether after-fit plots are produced
+    @param drawStackPlots Boolean deciding whether stacked before/after plots are produced, or just the individual histograms are stored
+    @param storeSingleFiles Boolean deciding whether single files will be created for each before/after plot
+    @param storeMergedFile Boolean deciding whether a central file will be created for all before/after plots
     @param drawCorrelationMatrix Boolean deciding whether correlation matrix plot is produced
     @param drawSeparateComponents Boolean deciding whether separate component (=sample) plots are produced
     @param drawLogLikelihood Boolean deciding whether log-likelihood plots are produced
@@ -57,7 +60,10 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawCorrelat
     
     log.debug('GenerateFitAndPlotCPP: anaName %s ' % anaName)
     log.debug("GenerateFitAndPlotCPP: drawBeforeFit %s " % drawBeforeFit) 
-    log.debug("GenerateFitAndPlotCPP: drawAfterFit %s " % drawAfterFit) 
+    log.debug("GenerateFitAndPlotCPP: drawAfterFit %s " % drawAfterFit)
+    log.debug("GenerateFitAndPlotCPP: drawStackPlots %s " % drawStackPlots)
+    log.debug("GenerateFitAndPlotCPP: storeSingleFiles %s " % storeSingleFiles)
+    log.debug("GenerateFitAndPlotCPP: storeMergedFile %s " % storeMergedFile)
     log.debug("GenerateFitAndPlotCPP: drawCorrelationMatrix %s " % drawCorrelationMatrix) 
     log.debug("GenerateFitAndPlotCPP: drawSeparateComponents %s " % drawSeparateComponents)
     log.debug("GenerateFitAndPlotCPP: drawLogLikelihood %s " % drawLogLikelihood)
@@ -69,7 +75,7 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawCorrelat
     log.debug(f"GenerateFitAndPlotCPP: noFit {noFit}")
     log.debug(f"GenerateFitAndPlotCPP: plotInterpolation {plotInterpolation}")
     
-    Util.GenerateFitAndPlot(fc.name, anaName, drawBeforeFit, drawAfterFit, drawCorrelationMatrix,
+    Util.GenerateFitAndPlot(fc.name, anaName, drawBeforeFit, drawAfterFit, drawStackPlots, storeSingleFiles, storeMergedFile, drawCorrelationMatrix,
                             drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation)
 
 if __name__ == "__main__":
@@ -411,9 +417,10 @@ if __name__ == "__main__":
 
             log.info("Running on fitConfig %s" % configMgr.fitConfigs[i].name)
             log.info(f"Setting noFit = {noFit}")
-            r = GenerateFitAndPlotCPP(configMgr.fitConfigs[i], configMgr.analysisName, drawBeforeFit, drawAfterFit, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, runMinos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, drawInterpolation)
+            r = GenerateFitAndPlotCPP(configMgr.fitConfigs[i], configMgr.analysisName, drawBeforeFit, drawAfterFit, configMgr.plotStacked, configMgr.storeSinglePlotFiles, configMgr.storeMergedPlotFile, 
+                                      drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, runMinos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, drawInterpolation)
         
-        log.debug(" GenerateFitAndPlotCPP(configMgr.fitConfigs[%d], configMgr.analysisName, drawBeforeFit, drawAfterFit, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, runMinos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, drawInterpolation)" % idx)
+        log.debug(" GenerateFitAndPlotCPP(configMgr.fitConfigs[%d], configMgr.analysisName, drawBeforeFit, drawAfterFit, configMgr.plotStacked, configMgr.storeSinglePlotFiles, configMgr.storeMergedPlotFile, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, runMinos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, drawInterpolation)" % idx)
         log.debug("   where drawBeforeFit, drawAfterFit, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, ReduceCorrMatrix, noFit, drawInterpolation are booleans")
         pass
 

--- a/src/ChannelStyle.cxx
+++ b/src/ChannelStyle.cxx
@@ -106,7 +106,7 @@ TString ChannelStyle::getSampleName(const TString& sample){
       m_logger << kVERBOSE << "getSampleName: requested sample name: "<<sample  
 	       << ", defined m_sampleNames[" << i << "]="<< m_sampleNames[i] << GEndl;
       TString target = m_sampleNames[i]+"_";
-      if( sample.Contains(target.Data())){
+      if( sample.BeginsWith(target.Data())){
             return m_sampleNames[i];
         }
     }

--- a/src/ChannelStyle.h
+++ b/src/ChannelStyle.h
@@ -48,6 +48,9 @@ class ChannelStyle : public TObject{
   Float_t getLumi(){ return m_lumi;}
   void setLumi(Double_t lumi){ m_lumi = lumi; }
 
+  TString getEnergy(){ return m_energy;}
+  void setEnergy(TString energy){ m_energy = energy; }
+
   TString getName(){ return m_name;}
   void setName(TString name){ m_name = name; }
 
@@ -173,6 +176,7 @@ private:
   TString m_name;
   TString m_title;
   Float_t m_lumi;
+  TString m_energy;
 
   Int_t m_dataColor;
   Int_t m_totalPdfColor;

--- a/src/HistogramPlotter.cxx
+++ b/src/HistogramPlotter.cxx
@@ -79,6 +79,9 @@ HistogramPlotter::HistogramPlotter(RooWorkspace *w, const TString& fitConfigName
     m_plotRegions = "ALL";
     m_plotComponents = true;
     m_plotSeparateComponents = false;
+    m_storeSingleFiles = true;
+    m_storeMergedFile = false;
+    m_doStackPlots = true;
 
     m_fitResult = nullptr;
     m_inputData = nullptr;
@@ -100,6 +103,9 @@ HistogramPlotter::HistogramPlotter(RooWorkspace* w, FitConfig* fc) {
     m_plotRatio = mgr->m_plotRatio;
     m_plotRegions = "ALL";
 
+    m_storeSingleFiles = true;
+    m_storeMergedFile = false;
+    m_doStackPlots = true;
 }
 
 HistogramPlotter::~HistogramPlotter() {
@@ -112,6 +118,18 @@ void HistogramPlotter::setPlotSeparateComponents(bool b) {
 
 void HistogramPlotter::setPlotComponents(bool b) {
     m_plotComponents = b;
+}
+
+void HistogramPlotter::setStoreSingleFiles(bool b) {
+    m_storeSingleFiles = b;
+}
+
+void HistogramPlotter::setStoreMergedFile(bool b) {
+    m_storeMergedFile = b;
+}
+
+void HistogramPlotter::setDoStackPlots(bool b) {
+    m_doStackPlots = b;
 }
 
 void HistogramPlotter::setPlotRegions(const TString &s) {
@@ -141,6 +159,7 @@ void HistogramPlotter::Initialize() {
     Logger << kINFO << "HistogramPlotter::Initialize()" << GEndl;
     Logger << kINFO << " ------ Starting Plot with parameters:   analysisName = " << m_fitConfig->m_name << " and " << m_anaName << GEndl;
     Logger << kINFO << "    plotRegions = '" <<  m_plotRegions <<  "'  plotComponents = " << m_plotComponents << "  outputPrefix = " << m_outputPrefix  << GEndl;
+    Logger << kINFO << "    storeSingleFiles = '" <<  m_storeSingleFiles <<  "'  storeMergedFiles = " << m_storeMergedFile << "  doStackPlot = " << m_doStackPlots  << GEndl;
 
     m_pdf = static_cast<RooSimultaneous*>(m_workspace->pdf("simPdf"));
     if(!m_inputData) {
@@ -160,6 +179,14 @@ void HistogramPlotter::Initialize() {
 
 void HistogramPlotter::PlotRegions() {
     Logger << kINFO << "Plotting all known regions in PDF" << GEndl;
+
+    if(m_storeMergedFile) {
+        m_mergedFile = ("results/" + m_anaName + "/histograms_" + m_outputPrefix + ".root");
+        Logger << kINFO << "Will store " << m_outputPrefix << " histograms in " << m_mergedFile << GEndl;
+        TFile *f = TFile::Open(m_mergedFile.Data(), "RECREATE");
+        f->Close();
+    }
+
     // loop loop loop
     for(const auto &categoryLabel : m_regions)  {
         // Does the region actually exist?
@@ -170,26 +197,6 @@ void HistogramPlotter::PlotRegions() {
 
         PlotRegion(categoryLabel);
     }
-}
-
-void HistogramPlotter::saveHistograms() {
-
-    std::string filename("results/" + m_anaName + "/histograms_" + m_outputPrefix + ".root");
-    TFile *f = TFile::Open(filename.c_str(), "RECREATE");
-
-    for(unsigned int i = 0; i < m_regions.size(); ++i){
-        const auto categoryLabel = m_regions[i];
-        const auto hists = m_histograms[i];
-
-        f->mkdir(categoryLabel);
-        f->cd(categoryLabel);
-        for(const auto &h : hists) {
-            h->Write();
-        }
-
-        f->cd();
-    }
-    f->Close();
 }
 
 void HistogramPlotter::PlotRegion(const TString &regionCategoryLabel) {
@@ -218,13 +225,36 @@ void HistogramPlotter::PlotRegion(const TString &regionCategoryLabel) {
     plot.setFitResult(m_fitResult);
     plot.setPlotComponents(m_plotComponents);
     plot.setOutputPrefix(m_outputPrefix);
-    //m_histograms.push_back(hists);
+    plot.setStoreSingleFiles(m_storeSingleFiles);
 
-    plot.plot();
-    plot.saveHistograms();
+    TFile *file = nullptr;
+    TDirectory *directory = nullptr;
+    if(m_storeMergedFile) {
+        //std::string filename("results/" + m_anaName + "/histograms_" + m_outputPrefix + ".root");
+        file = TFile::Open(m_mergedFile.Data(), "UPDATE");
+        directory = file->mkdir(regionCategoryLabel);
+    }
+
+    // This will write single files if m_storeSingleFiles was set, and write to the directory if it was set too
+    if(m_doStackPlots) plot.plot(directory);
+
+    if(m_storeSingleFiles) {
+        //TString canvasName(Form("%s_%s", regionCategoryLabel.Data(), m_outputPrefix.Data()));
+        std::string filename("results/" + m_anaName + "/" + regionCategoryLabel + ".root");
+        TFile *f = TFile::Open(filename.c_str(), "update");
+        plot.saveHistograms(f);
+        f->Close();
+    }
+
+    if(directory) {
+        plot.saveHistograms(directory);
+    }
+
     //if(m_plotSeparateComponents) {
     //plot.plotSeparateComponents();
     //}
+
+    if(file) file->Close();
 
 }
 
@@ -250,10 +280,15 @@ HistogramPlot::HistogramPlot(RooWorkspace *w,
 
     m_fitResult = nullptr;
     m_plotComponents = false;
+    m_storeSingleFiles = false;
 }
 
 void HistogramPlot::setPlotComponents(bool b) {
     m_plotComponents = b;
+}
+
+void HistogramPlot::setStoreSingleFiles(bool b) {
+    m_storeSingleFiles = b;
 }
 
 void HistogramPlot::setOutputPrefix(const TString& outputPrefix) {
@@ -687,7 +722,12 @@ TLegend* HistogramPlot::buildLegend() {
     return leg;
 }
 
-void HistogramPlot::plot() {
+void HistogramPlot::plot(TDirectory *directory) {
+    if(!m_storeSingleFiles && !directory){
+        Logger << kWARNING << "HistogramPlot::plot called with m_storeSingleFiles == false and directory == nullptr - nothing to do here!" << GEndl;
+        return;
+    }
+
     buildFrame();
 
     // Now build the canvas
@@ -766,9 +806,19 @@ void HistogramPlot::plot() {
     }
 
     // Write output
-    canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".pdf");
-    canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".eps");
-    canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".root");
+    if(m_storeSingleFiles) {
+        canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".pdf");
+        canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".eps");
+        canvas->SaveAs("results/" + m_anaName + "/" + canvasName + ".root");
+    }
+
+    // If required (i.e. if directory is set), store a copy
+    if(directory) {
+        TDirectory* currentDir = gDirectory->CurrentDirectory();
+        directory->cd();
+        canvas->Write();
+        currentDir->cd();
+    }
 }
 
 void HistogramPlot::plotSeparateComponents() {
@@ -863,18 +913,14 @@ void HistogramPlot::plotSingleComponent(unsigned int i, double normalisation) {
     leg->Draw();
 }
 
-void HistogramPlot::saveHistograms() {
+void HistogramPlot::saveHistograms(TDirectory *directory) {
     if(m_componentNames.empty()) {
         loadComponentInformation();
     }
 
     // Save the current directory to resume it after this function call
-    gDirectory->pwd();
     TDirectory* currentDir = gDirectory->CurrentDirectory();
-
-    // Try something here
-    TString canvasName(Form("%s_%s", m_regionCategoryLabel.Data(), m_outputPrefix.Data()));
-    TFile f(Form("results/%s/%s.root", m_anaName.Data(), canvasName.Data()), "update");
+    directory->cd();
 
     // Data hist
     RooPlot* frame_dummy = m_regionVariable->frame();
@@ -969,17 +1015,16 @@ void HistogramPlot::saveHistograms() {
         auto h = Util::ComponentToHistogram(m_componentPdfs[component], m_regionVariable, m_fitResult);
 
         h->SetFillColor(m_style.getSampleColor(component));
+
         h->SetName(m_style.getSampleName(component));
+        Logger << kINFO << component << GEndl;
         Logger << kINFO << "Rebinning histogram " << h->GetName() << GEndl;
         if (m_binEdges.size())
             h = remapHistogram(h);
         h->Write();
     }
 
-    Logger << kINFO << "Wrote histogram information to " << f.GetName() << GEndl;
-
-    // Close the output file
-    f.Close();
+    Logger << kINFO << "Wrote histogram information to: " << directory->GetPath() << GEndl;
 
     // Resume the previous directory
     currentDir->cd();

--- a/src/HistogramPlotter.cxx
+++ b/src/HistogramPlotter.cxx
@@ -791,7 +791,7 @@ void HistogramPlot::plot(TDirectory *directory) {
 
     // Lumi
     if(m_style.getShowLumi()){
-        Util::AddText(0.175, 0.775, Form("#int Ldt = %.1f fb^{-1}", m_style.getLumi() ));
+        Util::AddText(m_style.getLumiX(), m_style.getLumiY(), Form("#sqrt{s} = %s, %.1f fb^{-1}", m_style.getEnergy().Data(), m_style.getLumi() ));
     }
 
     // Legend

--- a/src/HistogramPlotter.h
+++ b/src/HistogramPlotter.h
@@ -59,12 +59,13 @@ class HistogramPlotter {
         void setPlotRegions(const TString& s);
         void setPlotComponents(bool b);
         void setPlotSeparateComponents(bool b);
+        void setStoreSingleFiles(bool b);
+        void setStoreMergedFile(bool b);
+        void setDoStackPlots(bool b);
 
         void Initialize();
         void PlotRegions();
         void PlotRegion(const TString& r);
-
-        void saveHistograms();
 
     private:
         RooWorkspace* m_workspace;
@@ -74,6 +75,10 @@ class HistogramPlotter {
 
         bool m_plotSeparateComponents;
         bool m_plotComponents;
+        bool m_storeSingleFiles;
+        bool m_storeMergedFile;
+        TString m_mergedFile;
+        bool m_doStackPlots;
         TString m_plotRegions;
         TString m_outputPrefix;
 
@@ -93,15 +98,16 @@ class HistogramPlotter {
 class HistogramPlot {
     public:
         HistogramPlot(RooWorkspace *w, const TString& r, RooAbsPdf *regionPdf, RooDataSet *regionData, const ChannelStyle &style);
-        void plot();
+        void plot(TDirectory *directory = nullptr);
 
-        void saveHistograms();
+        void saveHistograms(TDirectory *directory);
         void plotSeparateComponents();
 
         void setAnalysisName(const TString& anaName);
         void setOutputPrefix(const TString& outputPrefix);
         void setFitResult(RooFitResult *r);
         void setPlotComponents(bool b);
+        void setStoreSingleFiles(bool b);
 
     private:
         HistogramPlot();
@@ -135,6 +141,7 @@ class HistogramPlot {
         TString m_anaName;
 
         bool m_plotComponents;
+        bool m_storeSingleFiles;
         TString m_outputPrefix;
         TString m_plotRatio;
 

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -160,9 +160,11 @@ double Util::getNonQcdVal(const TString& proc, const TString& reg, TMap* map,con
 
 
 //_____________________________________________________________________________
-void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
+void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit,
+        Bool_t doStackPlots, Bool_t storeSingleFiles, Bool_t storeMergedFile,
+        Bool_t plotCorrelationMatrix,
         Bool_t plotSeparateComponents, Bool_t plotNLL, Bool_t minos, TString minosPars,
-        Bool_t doFixParameters, TString fixedPars, bool ReduceCorrMatrix, bool noFit, bool plotInterpolation ){
+        Bool_t doFixParameters, TString fixedPars, bool ReduceCorrMatrix, bool noFit, bool plotInterpolation){
 
     ConfigMgr* mgr = ConfigMgr::getInstance();
     FitConfig* fc = mgr->getFitConfig(fcName);
@@ -171,6 +173,9 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
     Logger << kINFO << "     analysisName = " << anaName << GEndl;
     Logger << kINFO << "     drawBeforeFit = " << drawBeforeFit << GEndl;
     Logger << kINFO << "     drawAfterFit = " << drawAfterFit << GEndl;
+    Logger << kINFO << "     doStackPlots = " << doStackPlots << GEndl;
+    Logger << kINFO << "     storeSingleFiles = " << storeSingleFiles << GEndl;
+    Logger << kINFO << "     storeMergedFile = " << storeMergedFile << GEndl;
     Logger << kINFO << "     plotCorrelationMatrix = " << plotCorrelationMatrix << GEndl;
     Logger << kINFO << "     plotSeparateComponents = " << plotSeparateComponents << GEndl;
     Logger << kINFO << "     plotNLL = " << plotNLL << GEndl;
@@ -280,13 +285,15 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         h.setPlotRegions(plotChannels);
         h.setPlotComponents(true);
         h.setPlotSeparateComponents(false);
+        h.setDoStackPlots(doStackPlots);
+        h.setStoreSingleFiles(storeSingleFiles);
+        h.setStoreMergedFile(storeMergedFile);
         h.setOutputPrefix("beforeFit");
         h.setFitResult(expResultBefore);
         h.setInputData(toyMC);
 
         h.Initialize();
         h.PlotRegions();
-        //h.saveHistograms();
     }
 
     // perform fit
@@ -318,6 +325,9 @@ void Util::GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBefore
         h.setPlotRegions(plotChannels);
         h.setPlotComponents(true);
         h.setPlotSeparateComponents(false);
+        h.setDoStackPlots(doStackPlots);
+        h.setStoreSingleFiles(storeSingleFiles);
+        h.setStoreMergedFile(storeMergedFile);
         h.setOutputPrefix("afterFit");
         h.setFitResult(expResultAfter);
         h.setInputData(toyMC);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -149,7 +149,9 @@ namespace Util
      @param noFit Don't re-run fit, but load parameter from after-fit workspace
      @param plotInterpolation plot the interpolation scheme
   */
-  void GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit, Bool_t plotCorrelationMatrix,
+  void GenerateFitAndPlot(TString fcName, TString anaName, Bool_t drawBeforeFit, Bool_t drawAfterFit,
+           Bool_t doStackPlots, Bool_t storeSingleFiles, Bool_t storeMergedFile,
+           Bool_t plotCorrelationMatrix,
 			  Bool_t plotSeparateComponents, Bool_t plotNLL,  Bool_t minos = kFALSE, TString minosPars="", Bool_t doFixParameters = kFALSE, TString fixedPars="", bool ReduceCorrMatrix = true, bool noFit = false, bool plotInterpolation = false);
 
   // Same as above, but now only for afterFit workspace

--- a/test/scripts/config_for_pytest.py
+++ b/test/scripts/config_for_pytest.py
@@ -104,6 +104,8 @@ configMgr.cutsDict = {"SR":"m>100.",
                       "SR_disc":"m>150.",
                       "CR":"m<100."}
 
+configMgr.outputLumi = configMgr.inputLumi = 140.1
+
 ####### Setup Data and Background Samples ############
 bkg1Sample = Sample("bkg1",TColor.GetColor('#fe9929')) 
 bkg1Sample.setStatConfig(useStat)
@@ -172,6 +174,7 @@ SRs.append(SR)
 # Don't include overflow
 for sr in SRs:
     sr.useOverflowBin = False
+    sr.showLumi = True
 
 cfg_fit.addSignalChannels(SRs)
     
@@ -179,6 +182,7 @@ cfg_fit.addSignalChannels(SRs)
 ## Control Regions
 CRs = list()
 CR = cfg_fit.addChannel('m',["CR"],1,50,100)
+CR.showLumi = True
 bkg2Sample.setNormRegions(["CR","m"])
 CRs.append(CR)
 

--- a/test/scripts/config_for_pytest.py
+++ b/test/scripts/config_for_pytest.py
@@ -19,6 +19,7 @@ gROOT.SetBatch(True)
 includeOverflowBin = True
 useStat    = True
 useToys = False
+manualBackupCache = None
 
 
 input_file = "test_tree.root"
@@ -27,12 +28,14 @@ nominal_tree_name = "_NoSys"
 
 parser = argparse.ArgumentParser(description="HistFitter Testing")
 parser.add_argument('--useToys', action="store_true")
+parser.add_argument('--manualBackupCache')
 
 
 if configMgr.userArg != "":
     args = parser.parse_args( configMgr.userArg.split() )
 
     useToys    = args.useToys
+    manualBackupCache = args.manualBackupCache
 
 # name for analysis, used in a lot of directory and filenames
 anaName = "hf_test"
@@ -64,9 +67,14 @@ try: os.mkdir('results/'+configMgr.analysisName )
 except: pass
 
 ##############
-configMgr.useCacheToTreeFallback = True
 configMgr.useHistBackupCacheFile = True # enable the use of an alternate data file
-configMgr.histBackupCacheFile =  "data/" + analysisNameBase + "/histCache.root" # the data file of your previous fit (= the backup cache file)
+if manualBackupCache is None:
+    configMgr.useCacheToTreeFallback = True
+    configMgr.histBackupCacheFile =  "data/" + analysisNameBase + "/histCache.root"
+else:
+    configMgr.useCacheToTreeFallback = False
+    configMgr.histBackupCacheFile =  manualBackupCache
+    configMgr.forceNorm = False # If we don't disable this, HF tries to build the Norm histograms from the trees anyways, even if useCacheToTreeFallback is set to Fale
 
 configMgr.outputFileName = "results/" + configMgr.analysisName  + "/Output.root"
 configMgr.histCacheFile = "data/" + analysisNameBase + "/histCache.root"
@@ -109,6 +117,7 @@ bkg2Sample.setSuffixTreeName("_nom")
 bkg2Sample.addInputs( [input_file] )
 bkg2Sample.setNormByTheory(False)
 bkg2Sample.setNormFactor("mu_bkg",1.,0.,10.)
+bkg2Sample.setNormRegions([('CR', 'm')])
 
 
 dataSample = Sample("data", kBlack)
@@ -121,12 +130,24 @@ sigSample.setNormByTheory(True)
 sigSample.setNormFactor("mu_SIG",1.,0,100)
 
 ######### Systematics
-bkg1Sample.addSystematic( Systematic('user_overallSys', '', 1.05, 0.95, 'user', 'overallSys') )
-bkg1Sample.addSystematic( Systematic('weight_sys', configMgr.weights, ['weight','sys_weight'], ['weight','1./sys_weight'], 'weight', 'histoSys') )
+bkg1Sample.addSystematic( Systematic('weight_histoSys', configMgr.weights, ['weight','sys_weight1'], ['weight','1./sys_weight1'], 'weight', 'histoSys') )
+bkg1Sample.addSystematic( Systematic('weight_overallSys', configMgr.weights, ['weight','sys_weight2'], ['weight','1./sys_weight2'], 'weight', 'overallSys') )
+bkg1Sample.addSystematic( Systematic('weight_overallHistoSys', configMgr.weights, ['weight','sys_weight3'], ['weight','1./sys_weight3'], 'weight', 'overallHistoSys') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysOneSide', configMgr.weights, ['weight', 'sys_weight4'], ['weight', 'sys_weight4'], 'weight', 'histoSysOneSide') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysOneSideSym', configMgr.weights, ['weight', 'sys_weight5'], ['weight', 'sys_weight5'], 'weight', 'histoSysOneSideSym') )
+bkg1Sample.addSystematic( Systematic('weight_histoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight6'], ['weight', '1/sys_weight6'], 'weight', 'histoSysEnvelopeSym') )
+bkg1Sample.addSystematic( Systematic('user_overallSys', '', 1.05, 0.95, 'user', 'userOverallSys') )
+bkg1Sample.addSystematic( Systematic('user_histoSys', '', 1.05, 0.95, 'user', 'userHistoSys') )
 
-bkg2Sample.addSystematic( Systematic('tree_sys', '', '_sys', '_sys', 'tree', 'normHistoSysOneSideSym') )
+bkg2Sample.addSystematic( Systematic('weight_overallNormSys', configMgr.weights, ['weight', 'sys_weight1'], ['weight', '1./sys_weight1'], 'weight', 'overallNormSys') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSys', configMgr.weights, ['weight', 'sys_weight2'], ['weight', '1./sys_weight2'], 'weight', 'normHistoSys') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSysOneSide', configMgr.weights, ['weight', 'sys_weight3'], ['weight', 'sys_weight3'], 'weight', 'normHistoSysOneSide') )
+bkg2Sample.addSystematic( Systematic('weight_normHistoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight4'], ['weight', '1./sys_weight4'], 'weight', 'normHistoSysEnvelopeSym') )
+bkg2Sample.addSystematic( Systematic('weight_overallNormHistoSysEnvelopeSym', configMgr.weights, ['weight', 'sys_weight5'], ['weight', '1./sys_weight5'], 'weight', 'overallNormHistoSysEnvelopeSym') )
+bkg2Sample.addSystematic( Systematic('tree_normHistoSysOneSideSym', '', '_sys', '_sys', 'tree', 'normHistoSysOneSideSym') )
+bkg2Sample.addSystematic( Systematic('user_normHistoSys', '', 1.05, 0.95, 'user', 'userNormHistoSys') )
 
-sigSample.addSystematic( Systematic('flat_sys', '', 1.10, 0.90, 'user', 'overallSys') )
+sigSample.addSystematic( Systematic('flat_sys', '', 1.10, 0.90, 'user', 'userOverallSys') )
 
 ########## Fit Config Base ##########
 bkgName = "BkgOnly"

--- a/test/scripts/genTree.C
+++ b/test/scripts/genTree.C
@@ -17,7 +17,12 @@ void genTree(){
 
     double m = 0; //{50,100,150,200}
     double weight = 1;
-    double sys_weight = 1;
+    double sys_weight1 = 1;
+    double sys_weight2 = 1;
+    double sys_weight3 = 1;
+    double sys_weight4 = 1;
+    double sys_weight5 = 1;
+    double sys_weight6 = 1;
 
     // Data tree
     TTree *data_tree = new TTree("data","data");
@@ -33,12 +38,23 @@ void genTree(){
     TTree *bkg1_tree = new TTree("bkg1_nom","bkg1_nom");
     bkg1_tree->Branch("m", &m, "m/D");
     bkg1_tree->Branch("weight", &weight, "weight/D");
-    bkg1_tree->Branch("sys_weight", &sys_weight, "sys_weight/D");
+    bkg1_tree->Branch("sys_weight1", &sys_weight1, "sys_weight1/D");
+    bkg1_tree->Branch("sys_weight2", &sys_weight2, "sys_weight2/D");
+    bkg1_tree->Branch("sys_weight3", &sys_weight3, "sys_weight3/D");
+    bkg1_tree->Branch("sys_weight4", &sys_weight4, "sys_weight4/D");
+    bkg1_tree->Branch("sys_weight5", &sys_weight5, "sys_weight5/D");
+    bkg1_tree->Branch("sys_weight6", &sys_weight6, "sys_weight6/D");
 
     // Bkg2 tree (falling)
     TTree *bkg2_nom_tree = new TTree("bkg2_nom","bkg2_nom");
     bkg2_nom_tree->Branch("m", &m, "m/D");
     bkg2_nom_tree->Branch("weight", &weight, "weight/D");
+    bkg2_nom_tree->Branch("sys_weight1", &sys_weight1, "sys_weight1/D");
+    bkg2_nom_tree->Branch("sys_weight2", &sys_weight2, "sys_weight2/D");
+    bkg2_nom_tree->Branch("sys_weight3", &sys_weight3, "sys_weight3/D");
+    bkg2_nom_tree->Branch("sys_weight4", &sys_weight4, "sys_weight4/D");
+    bkg2_nom_tree->Branch("sys_weight5", &sys_weight5, "sys_weight5/D");
+    bkg2_nom_tree->Branch("sys_weight6", &sys_weight6, "sys_weight6/D");
 
     TTree *bkg2_sys_tree = new TTree("bkg2_sys","bkg2_sys");
     bkg2_sys_tree->Branch("m", &m, "m/D");
@@ -75,7 +91,12 @@ void genTree(){
     {
         weight = norm;
         m = rnd.Uniform(150)+50.;
-        sys_weight = 1.03 + .05*(m-50.)/150.;
+        sys_weight1 = 1.03 + .05*(m-50.)/150.;
+        sys_weight2 = 1.02 + .01*(m-50.)/150.;
+        sys_weight3 = 1.01 + .02*(m-50.)/150.;
+        sys_weight4 = 1.02 + .03*(m-50.)/150.;
+        sys_weight5 = 1.03 + .04*(m-50.)/150.;
+        sys_weight6 = 1.01 + .06*(m-50.)/150.;
         bkg1_tree->Fill();
     }
 
@@ -84,6 +105,13 @@ void genTree(){
     { 
         weight = 1/3.;
         m = 75.;
+        float r = rnd.Uniform(30) + 75.;
+        sys_weight1 = 1.03 + .05*(m-75.)/30.;
+        sys_weight2 = 1.02 + .01*(m-75.)/30.;
+        sys_weight3 = 1.01 + .02*(m-75.)/30.;
+        sys_weight4 = 1.02 + .03*(m-75.)/30.;
+        sys_weight5 = 1.03 + .04*(m-75.)/30.;
+        sys_weight6 = 1.01 + .06*(m-75.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }
@@ -91,13 +119,27 @@ void genTree(){
     { 
         weight = 1/3.;
         m = 125.;
+        float r = rnd.Uniform(30) + 125.;
+        sys_weight1 = 1.03 + .05*(m-125.)/30.;
+        sys_weight2 = 1.02 + .01*(m-125.)/30.;
+        sys_weight3 = 1.01 + .02*(m-125.)/30.;
+        sys_weight4 = 1.02 + .03*(m-125.)/30.;
+        sys_weight5 = 1.03 + .04*(m-125.)/30.;
+        sys_weight6 = 1.01 + .06*(m-125.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }
     for (int i=0; i<3*(10-9); i++)
     { 
         weight = 1/3.;
-        m = 175.;   
+        m = 175.;
+        float r = rnd.Uniform(30) + 175.;
+        sys_weight1 = 1.03 + .05*(m-175.)/30.;
+        sys_weight2 = 1.02 + .01*(m-175.)/30.;
+        sys_weight3 = 1.01 + .02*(m-175.)/30.;
+        sys_weight4 = 1.02 + .03*(m-175.)/30.;
+        sys_weight5 = 1.03 + .04*(m-175.)/30.;
+        sys_weight6 = 1.01 + .06*(m-175.)/30.;
         bkg2_nom_tree->Fill(); 
         bkg2_sys_tree->Fill(); 
     }

--- a/test/test_fullchain.py
+++ b/test/test_fullchain.py
@@ -13,6 +13,123 @@ for k in f.GetListOfKeys():
     print(f"{k.GetName()}: {val},")
 """
 
+bkg_only_test_values = {
+    'hbkg1Nom_CR_obs_m': 3.2219999999999756, 
+    'hbkg1Nom_SR_obs_m': 5.777999999999959, 
+    'hbkg1user_histoSysHigh_CR_obs_m': 3.3830999999999745, 
+    'hbkg1user_histoSysHigh_SR_obs_m': 6.066899999999957, 
+    'hbkg1user_histoSysLow_CR_obs_m': 3.0608999999999766, 
+    'hbkg1user_histoSysLow_SR_obs_m': 5.489099999999961, 
+    'hbkg1user_overallSysHigh_CR_obs_m': 3.3830999999999745, 
+    'hbkg1user_overallSysHigh_SR_obs_m': 6.066899999999957, 
+    'hbkg1user_overallSysLow_CR_obs_m': 3.0608999999999766, 
+    'hbkg1user_overallSysLow_SR_obs_m': 5.489099999999961, 
+    'hbkg1weight_histoSysEnvelopeSymHigh_CR_obs_m': 3.2846586611647037, 
+    'hbkg1weight_histoSysEnvelopeSymHigh_SR_obs_m': 6.070510527144715, 
+    'hbkg1weight_histoSysEnvelopeSymLow_CR_obs_m': 3.1593413388352474, 
+    'hbkg1weight_histoSysEnvelopeSymLow_SR_obs_m': 5.485489472855202, 
+    'hbkg1weight_histoSysHigh_CR_obs_m': 3.3440255509705903, 
+    'hbkg1weight_histoSysHigh_SR_obs_m': 6.146948772620593, 
+    'hbkg1weight_histoSysLow_CR_obs_m': 3.1044935654749426, 
+    'hbkg1weight_histoSysLow_SR_obs_m': 5.43164435395858, 
+    'hbkg1weight_histoSysOneSideHigh_CR_obs_m': 3.301659330582352, 
+    'hbkg1weight_histoSysOneSideHigh_SR_obs_m': 6.010925263572357, 
+    'hbkg1weight_histoSysOneSideLow_CR_obs_m': 3.301659330582352, 
+    'hbkg1weight_histoSysOneSideLow_SR_obs_m': 6.010925263572357, 
+    'hbkg1weight_histoSysOneSideSymHigh_CR_obs_m': 3.3389524407764695, 
+    'hbkg1weight_histoSysOneSideSymHigh_SR_obs_m': 6.107827018096476, 
+    'hbkg1weight_histoSysOneSideSymLow_CR_obs_m': 3.1050475592234816, 
+    'hbkg1weight_histoSysOneSideSymLow_SR_obs_m': 5.448172981903442, 
+    'hbkg1weight_overallHistoSysHigh_CR_obs_m': 3.264366220388233, 
+    'hbkg1weight_overallHistoSysHigh_CR_obs_mNorm': 3.221999999999975, 
+    'hbkg1weight_overallHistoSysHigh_SR_obs_m': 5.914023509048238, 
+    'hbkg1weight_overallHistoSysHigh_SR_obs_mNorm': 5.77799999999996, 
+    'hbkg1weight_overallHistoSysLow_CR_obs_m': 3.1801950365209026, 
+    'hbkg1weight_overallHistoSysLow_CR_obs_mNorm': 3.221999999999975, 
+    'hbkg1weight_overallHistoSysLow_SR_obs_m': 5.645185558107728, 
+    'hbkg1weight_overallHistoSysLow_SR_obs_mNorm': 5.777999999999958, 
+    'hbkg1weight_overallSysHigh_CR_obs_m': 3.2915131101941175, 
+    'hbkg1weight_overallSysHigh_SR_obs_m': 5.9326817545241175, 
+    'hbkg1weight_overallSysLow_CR_obs_m': 3.1539577128203415, 
+    'hbkg1weight_overallSysLow_SR_obs_m': 5.627371169475674, 
+    'hbkg2Nom_CRNorm': 90.99999999999979, 
+    'hbkg2Nom_CR_obs_m': 90.99999999999979, 
+    'hbkg2Nom_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CRNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CR_obs_m': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymHigh_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CRNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CR_obs_m': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2tree_normHistoSysOneSideSymLow_SR_obs_m': 12.000000000000002, 
+    'hbkg2tree_normHistoSysOneSideSymLow_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2user_normHistoSysHigh_CRNorm': 95.54999999999978, 
+    'hbkg2user_normHistoSysHigh_CR_obs_m': 95.54999999999978, 
+    'hbkg2user_normHistoSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2user_normHistoSysHigh_SR_obs_m': 12.600000000000003, 
+    'hbkg2user_normHistoSysHigh_SR_obs_mNorm': 12.000000000000002, 
+    'hbkg2user_normHistoSysLow_CRNorm': 86.44999999999979, 
+    'hbkg2user_normHistoSysLow_CR_obs_m': 86.44999999999979, 
+    'hbkg2user_normHistoSysLow_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2user_normHistoSysLow_SR_obs_m': 11.4, 
+    'hbkg2user_normHistoSysLow_SR_obs_mNorm': 12.0, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CRNorm': 92.82000000000059, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CR_obs_m': 92.82000000000059, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_SR_obs_m': 12.239999999999997, 
+    'hbkg2weight_normHistoSysEnvelopeSymHigh_SR_obs_mNorm': 11.999999999999892, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CRNorm': 89.2156862745101, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CR_obs_m': 89.17999999999898, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_CR_obs_mNorm': 90.96359999999845, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_SR_obs_m': 11.760000000000007, 
+    'hbkg2weight_normHistoSysEnvelopeSymLow_SR_obs_mNorm': 11.995199999999938, 
+    'hbkg2weight_normHistoSysHigh_CRNorm': 92.82000000000059, 
+    'hbkg2weight_normHistoSysHigh_CR_obs_m': 92.82000000000059, 
+    'hbkg2weight_normHistoSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysHigh_SR_obs_m': 12.239999999999997, 
+    'hbkg2weight_normHistoSysHigh_SR_obs_mNorm': 11.999999999999892, 
+    'hbkg2weight_normHistoSysLow_CRNorm': 89.2156862745101, 
+    'hbkg2weight_normHistoSysLow_CR_obs_m': 89.2156862745101, 
+    'hbkg2weight_normHistoSysLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_normHistoSysLow_SR_obs_m': 11.764705882352942, 
+    'hbkg2weight_normHistoSysLow_SR_obs_mNorm': 11.999999999999932, 
+    'hbkg2weight_normHistoSysOneSideHigh_CRNorm': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideHigh_CR_obs_m': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideHigh_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2weight_normHistoSysOneSideHigh_SR_obs_m': 12.119999999999997, 
+    'hbkg2weight_normHistoSysOneSideHigh_SR_obs_mNorm': 11.999999999999913, 
+    'hbkg2weight_normHistoSysOneSideLow_CRNorm': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideLow_CR_obs_m': 91.91000000000042, 
+    'hbkg2weight_normHistoSysOneSideLow_CR_obs_mNorm': 90.99999999999977, 
+    'hbkg2weight_normHistoSysOneSideLow_SR_obs_m': 12.119999999999997, 
+    'hbkg2weight_normHistoSysOneSideLow_SR_obs_mNorm': 11.999999999999913, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CRNorm': 93.73000000000009, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CR_obs_m': 93.73000000000009, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_SR_obs_m': 12.360000000000007, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymHigh_SR_obs_mNorm': 12.000000000000004, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CRNorm': 88.34951456310662, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CR_obs_m': 88.26999999999948, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_SR_obs_m': 11.639999999999997, 
+    'hbkg2weight_overallNormHistoSysEnvelopeSymLow_SR_obs_mNorm': 12.0, 
+    'hbkg2weight_overallNormSysHigh_CRNorm': 93.73000000000009, 
+    'hbkg2weight_overallNormSysHigh_CR_obs_m': 93.73000000000009, 
+    'hbkg2weight_overallNormSysHigh_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormSysHigh_SR_obs_m': 12.360000000000007, 
+    'hbkg2weight_overallNormSysHigh_SR_obs_mNorm': 12.000000000000004, 
+    'hbkg2weight_overallNormSysLow_CRNorm': 88.34951456310662, 
+    'hbkg2weight_overallNormSysLow_CR_obs_m': 88.34951456310662, 
+    'hbkg2weight_overallNormSysLow_CR_obs_mNorm': 90.99999999999979, 
+    'hbkg2weight_overallNormSysLow_SR_obs_m': 11.650485436893199, 
+    'hbkg2weight_overallNormSysLow_SR_obs_mNorm': 12.0, 
+    'hdata_CR_obs_m': 105.0, 
+    'hdata_SR_obs_m': 21.0
+}
+
+
 def test_treeToHist(script_runner):
 
     # Make input TTree if needed
@@ -28,35 +145,38 @@ def test_treeToHist(script_runner):
     assert os.path.isfile("data/hf_test/histCache.root") # histcache generated
 
     # values from snippet above
-    test_values = {
-        "hbkg1Nom_CR_obs_m": 3.2219999999999756,
-        "hbkg1Nom_SR_obs_m": 5.777999999999959,
-        "hbkg1user_overallSysHigh_CR_obs_m": 3.3830999999999745,
-        "hbkg1user_overallSysHigh_SR_obs_m": 6.066899999999957,
-        "hbkg1user_overallSysLow_CR_obs_m": 3.0608999999999766,
-        "hbkg1user_overallSysLow_SR_obs_m": 5.489099999999961,
-        "hbkg1weight_sysHigh_CR_obs_m": 3.3440255509705903,
-        "hbkg1weight_sysHigh_SR_obs_m": 6.146948772620593,
-        "hbkg1weight_sysLow_CR_obs_m": 3.1044935654749426,
-        "hbkg1weight_sysLow_SR_obs_m": 5.43164435395858,
-        "hbkg2Nom_CR_obs_m": 90.99999999999979,
-        "hbkg2Nom_SR_obs_m": 12.000000000000002,
-        "hbkg2tree_sysHigh_CR_obs_m": 90.99999999999979,
-        "hbkg2tree_sysHigh_SR_obs_m": 12.000000000000002,
-        "hbkg2tree_sysLow_CR_obs_m": 90.99999999999979,
-        "hbkg2tree_sysLow_SR_obs_m": 12.000000000000002,
-        "hdata_CR_obs_m": 105.0,
-        "hdata_SR_obs_m": 21.0
-    }
-
     hc = ROOT.TFile("data/hf_test/histCache.root")
     for k in hc.GetListOfKeys():
         name = k.GetName()
         val = hc.Get(name).Integral()
 
-        assert math.isclose(test_values[name], val) # histogram integral matches test values
+        assert math.isclose(bkg_only_test_values[name], val) # histogram integral matches test values
 
 
+def test_backupCache(script_runner):
+    command = 'mv ${HISTFITTER}/test/data/hf_test/histCache.root ${HISTFITTER}/test/test_backup_cache.root'
+    (ret, outRaw, errRaw) = script_runner(command)
+
+    hc = ROOT.TFile.Open('test_backup_cache.root', 'UPDATE')
+    for k in hc.GetListOfKeys():
+        name = k.GetName()
+        if name.endswith('mNorm'):
+            hc.Delete(f'{name};*')
+    hc.Close()
+
+    command = "HistFitter.py -w -u='--manualBackupCache ${HISTFITTER}/test/test_backup_cache.root' ${HISTFITTER}/test/scripts/config_for_pytest.py"
+    (ret,outRaw,errRaw) = script_runner(command)
+    assert ret.returncode == 0
+
+    assert os.path.isfile("data/hf_test/histCache.root") # histcache generated
+
+    # values from snippet above
+    hc = ROOT.TFile("data/hf_test/histCache.root")
+    for k in hc.GetListOfKeys():
+        name = k.GetName()
+        val = hc.Get(name).Integral()
+
+        assert math.isclose(bkg_only_test_values[name], val) # histogram integral matches test values
 
 def test_bkgFit(script_runner):
 
@@ -135,7 +255,7 @@ def test_sigExclusionAll(script_runner):
     with open('sysTable.tex') as f:
         contents = f.read()
         assert "Total background expectation             &  $5.7" in contents # bkg 1 yield
-        assert "Total background systematic               & $\\pm 0.7" in contents # bkg 1 sys
+        assert "Total background systematic               & $\\pm 0.9" in contents # bkg 1 sys
         
 
     # Exclusion Asymptotics
@@ -190,4 +310,4 @@ def test_discoveryAll(script_runner):
 
     with open('ulTable.tex') as f:
         contents = f.read()
-        assert 'SR\\_disc    & $0.75$ &  $7.5$ & $ { 5.6 }^{ +2.9 }_{ -1.8 }$ & $0.75$ & $ 0.21$~$(0.82)$' in contents # UL table
+        assert 'SR\\_disc    & $0.75$ &  $7.5$ & $ { 5.6 }^{ +3.0 }_{ -1.8 }$ & $0.75$ & $ 0.21$~$(0.81)$' in contents # UL table


### PR DESCRIPTION
This MR includes:
- A bug fix on ChannelStyle::getSampleName, that previously resulted in wrong histogram names for each sample in the root file produced for both before/after fit plots, if the channel name contains the substring "<sample>_"
- Added an option to store all before/after fit plots in a single file.
- Added option to not produce stacked before/after plots, but instead only produce the individual process, SM-total, data, and ratio plots. This saves about 50% of the time, since because of how RooPlot works, the PDF extraction from the workspace always runs again when producing the stack plot. Given that the PDF extraction step is very slow, this can reduce the time required to produce plots by many hours.
- Updated the luminosity label to the new ATLAS style, without the integral sign. Added the center-of-mass energy to the luminosity label.