### PR TITLE
Pytest updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -qq -y update && \
     cp /root/.bashrc /home/docker/ && \
     chown -R --from=root docker /home/docker && \
     chown -R --from=root docker /usr/local/HistFitter && \
-    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel pytest-order && \
     python -m pip --no-cache-dir install --requirement /usr/local/HistFitter/requirements.txt
 
 # Build HistFitter, make $HOME/.local/bin for .profile to find and add to PATH,

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 # tests
 pytest~=6.2
+pytest-order~=1.1.0
 # develop
 pre-commit~=2.13
 pyupgrade~=2.19

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,7 +11,7 @@ def script_runner():
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
         )
         try:
-            out,err = proc.communicate(timeout=120)
+            out,err = proc.communicate(timeout=240)
             return (proc,out,err)
         except TimeoutExpired:
             print("script_runner timedout")

--- a/test/scripts/config_for_pytest.py
+++ b/test/scripts/config_for_pytest.py
@@ -5,7 +5,7 @@ from ROOT import kBlack,kWhite,kGray,kRed,kPink,kMagenta,kViolet,kBlue,kAzure,kC
 from ROOT import TColor
 from configWriter import fitConfig,Measurement,Channel,Sample
 from systematic import Systematic
-import math,ROOT,os
+import ROOT,os
 
 from inspect import getframeinfo, currentframe
 

--- a/test/test_fullchain.py
+++ b/test/test_fullchain.py
@@ -1,6 +1,7 @@
 import ROOT
 
 import os
+import time
 import math
 import pytest
 
@@ -134,11 +135,18 @@ bkg_only_test_values = {
 @pytest.mark.order(1)
 def test_treeToHist(script_runner):
 
+    if os.path.isfile("test_tree.root"):
+        # Check if ttree file is old, and remove to avoid getting caught offguard by changes
+        if time.time() - os.path.getctime("test_tree.root") > 86400.: # 24 hours in seconds
+            os.remove("test_tree.root")
+
+
     # Make input TTree if needed
     if not os.path.isfile("test_tree.root"): 
         command = "root -l -b -q ${HISTFITTER}/test/scripts/genTree.C+"
         (ret,outRaw,errRaw) = script_runner(command)
         assert ret.returncode == 0 # ROOT file with TTrees generated
+
 
     command = "HistFitter.py -t ${HISTFITTER}/test/scripts/config_for_pytest.py"
     (ret,outRaw,errRaw) = script_runner(command)


### PR DESCRIPTION
A few updates to the pytests to make sure it's not cutoff by the timeout, the ttree file is fresh, and a few tests are run in a fixed order.  This last bit requires pytest-order.