### PR TITLE
Broken prefit uncertainties in YieldsTables and Plots

### DIFF
--- a/scripts/YieldsTable.py
+++ b/scripts/YieldsTable.py
@@ -422,7 +422,7 @@ def latexfitresults(filename,regionList,sampleList,dataname='obsData',showSum=Fa
   tablenumbers['TOTAL_MC_EXP_BKG_err']    =  pdfExpErrInRegionList
   
   """
-  calculate the fitted number of events and propagated error for each requested sample, by splitting off each sample pdf
+  calculate the before-fit number of events and propagated error for each requested sample, by splitting off each sample pdf
   """
   for isam, sample in enumerate(sampleList):
     sampleName=getName(sample)

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -2614,12 +2614,9 @@ Util::resetError( RooWorkspace* wspace, const RooArgList& parList, const RooArgL
                     << GEndl;
                 continue;
             }
-            // Get the uncertainty on the Lumi:
-            RooRealVar* lumiSigma = (RooRealVar*) lumiConstr->findServer(0);
-            sigma = lumiSigma->getVal();
 
-            RooRealVar* nominalLumi = wspace->var("nominalLumi");
-            double val_nom = nominalLumi->getVal();
+            double val_nom = lumiConstr->getMean().getVal();
+            sigma = lumiConstr->getSigma().getVal();
 
             val_hi  = val_nom + sigma;
             val_low = val_nom - sigma;

--- a/src/Utils.cxx
+++ b/src/Utils.cxx
@@ -562,7 +562,7 @@ void Util::SaveInitialSnapshot(RooWorkspace* w){
 
     RooAbsData* data = (RooAbsData*) w->data("obsData");
     RooArgSet* params = (RooArgSet*) pdf->getParameters(*data) ;
-    if(!w->loadSnapshot("snapshot_paramsVals_initial")) {
+    if(!w->getSnapshots().find("snapshot_paramsVals_initial")) {
         w->saveSnapshot("snapshot_paramsVals_initial",*params);
     } else {
         Logger << kWARNING << "Snapshot 'snapshot_paramsVals_initial' already exists in  workspace, will not overwrite it" << GEndl;


### PR DESCRIPTION
This PR addresses #160, where wrong prefit uncertainties were being calculated while building the yield table (using YieldsTable.py), or while drawing before-fit histograms (with HistFitter.py -D before ...).

This bug was caused by a change between ROOT 6.26 and 6.2 of the order in which the lumiConstraint RooGausian variable stored its RooStat variable servers. The cause of the problem and the implemented solution is described in more details in #160. The code used to obtain the nominal luminosity value was also simplified.

A minor update to Util::SaveInitialSnapshot was also added, to remove an unnecessary warning that was being raised on every HF execution.