### PR TITLE
Update python path for extra files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will create an install directory with the installed libraries as well as ot
 
 ## Setup
 
-The environment must be set by activating the setup script (`install/bin/histfitter_setup.sh`) in the directory where you want to work. This will create five new directorys in your work directory: `analysis`, `config`, `data`, `macros`, and `results`. It also copies the `HistFactorySchema.dtd` file into the config directory. Most importantly, the setup script sets the environment variable paths that are required for the scripts to work.
+The environment must be set by activating the setup script (`install/bin/histfitter_setup.sh`) in the directory where you want to work. This will create five new directorys in your work directory: `analysis`, `config`, `data`, `macros`, and `results`. It also copies the `HistFactorySchema.dtd` file into the config directory. Most importantly, the setup script sets the environment variable paths that are required for the scripts to work.  The setup also adds the analysis directory in the working area to the Python path.  This makes it convenient to import additional python files without needing to install them in the build area.
 
 ```
 source /path/to/install/bin/histfitter_setup.sh

--- a/histfitter_env_setup.sh
+++ b/histfitter_env_setup.sh
@@ -61,10 +61,10 @@ export HISTFITTER_VERSION=$VERSION
 
 #Find location of script
 if [ ! -z "${BASH_VERSION}" ]; then
-  #Find location of script
+  #Find location of this script in the install area
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 elif [ ! -z "${ZSH_VERSION}" ]; then 
-  #Find location of script
+  #Find location of this script in the install area
   SCRIPT_DIR="${0:A:h}"
 else
   echo "Please source this script using a bash or zsh shell.";

--- a/setup_histfitter.sh
+++ b/setup_histfitter.sh
@@ -44,6 +44,8 @@ echo "Setting the HISTFITTER_WORKDIR variable to $HISTFITTER_WORKDIR"
 #Set other paths
 source "$SCRIPT_DIR/histfitter_env_setup.sh"
 
+export PYTHONPATH=$PYTHONPATH:$HISTFITTER_WORKDIR/analysis
+
 #Set up HistFitter environment with folders
 if [[ ! -d "$HISTFITTER_WORKDIR/config" || ! -d "$HISTFITTER_WORKDIR/results" || ! -d "$HISTFITTER_WORKDIR/data" ]]; then
     echo "Making directories ./config ./results ./data in $HISTFITTER_WORKDIR"


### PR DESCRIPTION
This adds the analysis directory in the working area to the python path.  This makes it easy to import separate python files in the config.  This could previously be done by adding them to the python folder, but with the new build and install there are extra steps that are undesirable for including analysis specific python files, and is not possible when using a central build.