### PR TITLE
Fix for different variable names when computing normalization for norm regions

### DIFF
--- a/python/systematic.py
+++ b/python/systematic.py
@@ -570,7 +570,7 @@ class UserSystematic(SystematicBase):
                         abstract.hists[histName] = TH1D(histName, histName, 1, 0.5, 1.5)
                         totNorm=0.0
                         for normReg in sam.normRegions:
-                            nameTmp = "h" + sam.name + lowhigh + normReg[0] + "_obs_" + replaceSymbols(chan.variableName)
+                            nameTmp = "h" + sam.name + lowhigh + normReg[0] + "_obs_" + replaceSymbols(normReg[1])
                             try:
                                 totNorm += abstract.hists[nameTmp].GetSumOfWeights()
                             except:


### PR DESCRIPTION
This fixes what I assume to be bug in which the total normalization for the norm regions are not computed correctly if the norm regions include more than one region binned in different variables.
This is because as of now the variable name used when looping over the norm regions is the same as that of the channel for which the normalization of the systematic is currently being applied to.
So when computing the total normalization it will fail to find the histograms for norm regions that are binned in a different variable and the systematics will not get normalized correctly.
