### PR TITLE
217/212 Plot norm in combined TCanvas and plot overwriting 

### DIFF
--- a/analysis/tutorial/MyUserAnalysis.py
+++ b/analysis/tutorial/MyUserAnalysis.py
@@ -60,7 +60,8 @@ configMgr.testStatType=3   # 3=one-sided profile likelihood test statistic (LHC 
 configMgr.nPoints=20       # number of values scanned of signal-strength for upper-limit determination of signal strength.
 
 configMgr.writeXML = True
-
+configMgr.storeSinglePlotFiles = True
+configMgr.storeMergedPlotFile = False
 ##########################
 
 # Keep SRs also in background fit confuguration

--- a/scripts/HistFitter.py
+++ b/scripts/HistFitter.py
@@ -45,7 +45,7 @@ import usepyhf
 #Create logger
 log = Logger('HistFitter')
 
-def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawStackPlots, storeSingleFiles, storeMergedFile, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation):
+def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, plotStacked, storeSinglePlotFiles, storeMergedPlotFile, drawCorrelationMatrix, drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation):
     """ 
     function call to top-level C++ side function Util.GenerateFitAndPlot()
 
@@ -53,9 +53,9 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawStackPlo
     @param anaName Analysis name defined in config file, mainly used for output file/dir naming
     @param drawBeforeFit Boolean deciding whether before-fit plots are produced
     @param drawAfterFit Boolean deciding whether after-fit plots are produced
-    @param drawStackPlots Boolean deciding whether stacked before/after plots are produced, or just the individual histograms are stored
-    @param storeSingleFiles Boolean deciding whether single files will be created for each before/after plot
-    @param storeMergedFile Boolean deciding whether a central file will be created for all before/after plots
+    @param plotStacked Boolean deciding whether stacked before/after plots are produced, or just the individual histograms are stored
+    @param storeSinglePlotFiles Boolean deciding whether single files will be created for each before/after plot
+    @param storeMergedPlotFile Boolean deciding whether a central file will be created for all before/after plots
     @param drawCorrelationMatrix Boolean deciding whether correlation matrix plot is produced
     @param drawSeparateComponents Boolean deciding whether separate component (=sample) plots are produced
     @param drawLogLikelihood Boolean deciding whether log-likelihood plots are produced
@@ -71,9 +71,9 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawStackPlo
     log.debug('GenerateFitAndPlotCPP: anaName %s ' % anaName)
     log.debug("GenerateFitAndPlotCPP: drawBeforeFit %s " % drawBeforeFit) 
     log.debug("GenerateFitAndPlotCPP: drawAfterFit %s " % drawAfterFit)
-    log.debug("GenerateFitAndPlotCPP: drawStackPlots %s " % drawStackPlots)
-    log.debug("GenerateFitAndPlotCPP: storeSingleFiles %s " % storeSingleFiles)
-    log.debug("GenerateFitAndPlotCPP: storeMergedFile %s " % storeMergedFile)
+    log.debug("GenerateFitAndPlotCPP: plotStacked %s " % plotStacked)
+    log.debug("GenerateFitAndPlotCPP: storeSinglePlotFiles %s " % storeSinglePlotFiles)
+    log.debug("GenerateFitAndPlotCPP: storeMergedPlotFile %s " % storeMergedPlotFile)
     log.debug("GenerateFitAndPlotCPP: drawCorrelationMatrix %s " % drawCorrelationMatrix) 
     log.debug("GenerateFitAndPlotCPP: drawSeparateComponents %s " % drawSeparateComponents)
     log.debug("GenerateFitAndPlotCPP: drawLogLikelihood %s " % drawLogLikelihood)
@@ -85,7 +85,7 @@ def GenerateFitAndPlotCPP(fc, anaName, drawBeforeFit, drawAfterFit, drawStackPlo
     log.debug(f"GenerateFitAndPlotCPP: noFit {noFit}")
     log.debug(f"GenerateFitAndPlotCPP: plotInterpolation {plotInterpolation}")
     
-    Util.GenerateFitAndPlot(fc.name, anaName, drawBeforeFit, drawAfterFit, drawStackPlots, storeSingleFiles, storeMergedFile, drawCorrelationMatrix,
+    Util.GenerateFitAndPlot(fc.name, anaName, drawBeforeFit, drawAfterFit, plotStacked, storeSinglePlotFiles, storeMergedPlotFile, drawCorrelationMatrix,
                             drawSeparateComponents, drawLogLikelihood, minos, minosPars, doFixParameters, fixedPars, ReduceCorrMatrix, noFit, plotInterpolation)
 
 if __name__ == "__main__":

--- a/src/HistogramPlotter.cxx
+++ b/src/HistogramPlotter.cxx
@@ -245,14 +245,14 @@ void hf::HistogramPlotter::PlotRegion(const TString &regionCategoryLabel) {
 
     if(m_storeSingleFiles) {
         //TString canvasName(Form("%s_%s", regionCategoryLabel.Data(), m_outputPrefix.Data()));
-        std::string filename("results/" + m_anaName + "/" + regionCategoryLabel + ".root");
+        std::string filename("results/" + m_anaName + "/" + regionCategoryLabel +"_" + m_outputPrefix + ".root");
         TFile *f = TFile::Open(filename.c_str(), "update");
-        plot.saveHistograms(f);
+        plot.saveHistograms(f, m_outputPrefix);
         f->Close();
     }
 
     if(directory) {
-        plot.saveHistograms(directory);
+        plot.saveHistograms(directory, m_outputPrefix);
     }
 
     //if(m_plotSeparateComponents) {
@@ -918,7 +918,7 @@ void hf::HistogramPlot::plotSingleComponent(unsigned int i, double normalisation
     leg->Draw();
 }
 
-void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
+void hf::HistogramPlot::saveHistograms(TDirectory *directory, const TString &outputPrefix) {
     if(m_componentNames.empty()) {
         loadComponentInformation();
     }
@@ -944,7 +944,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
     mc_hist->SetLineColor(m_style.getTotalPdfColor());
     if (m_binEdges.size())
         mc_hist = remapHistogram(mc_hist);
-    mc_hist->Write("SM_total");
+    mc_hist->Write("SM_total_"+outputPrefix);
 
     // Data/model ratio
     auto hratio = hf::Util::MakeRatioOrPullHist(m_regionData, m_regionPdf, m_regionVariable);
@@ -954,7 +954,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
         TGraphAsymmErrors* g_hratio = remapGraph(static_cast<TGraphAsymmErrors*>(hratio), static_cast<TGraphAsymmErrors*>(data_hist));
         hratio = static_cast<RooHist*>(g_hratio);
     }
-    hratio->Write("h_ratio"); // "ratio" is a reserved keyword in root
+    hratio->Write("h_ratio_"+outputPrefix); // "ratio" is a reserved keyword in root
 
     // Data/bkg ratio -- check if we have a POI, if so, calculate the ratio with it set to 0
     RooStats::ModelConfig* mc = hf::Util::GetModelConfig( m_workspace );
@@ -978,7 +978,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
             TGraphAsymmErrors* g_hratio2 = remapGraph(static_cast<TGraphAsymmErrors*>(hratio2), static_cast<TGraphAsymmErrors*>(data_hist));
             hratio2 = static_cast<RooHist*>(g_hratio2);
         }
-        hratio2->Write("h_ratio_excl_sig");
+        hratio2->Write("h_ratio_excl_sig_"+outputPrefix);
 
         poi->setVal(poi_val_old);
     }
@@ -994,7 +994,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
         if (m_binEdges.size()) {
             remapCurve(hratioPdfError);
         }
-        hratioPdfError->Write("h_rel_error_band");
+        hratioPdfError->Write("h_rel_error_band_"+outputPrefix);
 
         // We get the total error directly from RooFit
         // Needs to be drawn again for some reason; we cannot just get it from above and using m_frame
@@ -1012,7 +1012,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
         if (m_binEdges.size()) {
             remapCurve(total_err);
         }
-        total_err->Write("h_total_error_band");
+        total_err->Write("h_total_error_band_"+outputPrefix);
     }
 
     // Every seperate component
@@ -1021,7 +1021,7 @@ void hf::HistogramPlot::saveHistograms(TDirectory *directory) {
 
         h->SetFillColor(m_style.getSampleColor(component));
 
-        h->SetName(m_style.getSampleName(component));
+        h->SetName(m_style.getSampleName(component)+"_"+outputPrefix);
         Logger << kINFO << component << GEndl;
         Logger << kINFO << "Rebinning histogram " << h->GetName() << GEndl;
         if (m_binEdges.size())

--- a/src/HistogramPlotter.cxx
+++ b/src/HistogramPlotter.cxx
@@ -622,7 +622,11 @@ void hf::HistogramPlot::addComponents() {
 
         m_regionPdf->plotOn(m_frame, //RooFit::Normalization(1, RooAbsReal::RelativeExpected),
                 RooFit::Components(m_componentStackedNames[i].Data()),
-                RooFit::Normalization(m_componentStackedFractions[i]*normalisation, RooAbsReal::NumEvent),
+                #if ROOT_VERSION_CODE >= ROOT_VERSION(6,30,0)
+                    RooFit::Normalization(normalisation, RooAbsReal::NumEvent),
+                #else
+                    RooFit::Normalization(m_componentStackedFractions[i]*normalisation, RooAbsReal::NumEvent),
+                #endif
                 RooFit::FillColor(color),
                 RooFit::FillStyle(1001),
                 RooFit::DrawOption("F"),

--- a/src/HistogramPlotter.h
+++ b/src/HistogramPlotter.h
@@ -110,7 +110,7 @@ class HistogramPlot {
         HistogramPlot(RooWorkspace *w, const TString& r, RooAbsPdf *regionPdf, RooDataSet *regionData, const hf::ChannelStyle &style);
         void plot(TDirectory *directory = nullptr);
 
-        void saveHistograms(TDirectory *directory);
+        void saveHistograms(TDirectory *directory, const TString &outputPrefix);
         void plotSeparateComponents();
 
         void setAnalysisName(const TString& anaName);


### PR DESCRIPTION
* Add before/after to filename and plots to avoid overwriting, closes #212 
* Fix normalization in plotOn call for ROOT >=6.30.  Only impacted combined TCanvas, not individual plots, closes #217
* Rename some options to be the same as c++ function 