### PR TITLE
Fix parser printing options for harvestToContours

### DIFF
--- a/scripts/harvestToContours.py
+++ b/scripts/harvestToContours.py
@@ -54,7 +54,7 @@ parser.add_argument("--outputFile","-o", type = str, help="output ROOT file", de
 parser.add_argument("--interpolation",   type = str, help="interpolation function for scipy (RBF): linear, cubic, gaussian, multiquadric or (griddata): nearest, linear, cubic", default = "multiquadric")
 parser.add_argument("--interpolationScheme",   type = str, help="type of interpolation for scipy: rbf, griddata", default = "rbf")
 parser.add_argument("--interpolationEpsilon", type=float, help="scipy (RBF) epsilon parameter", default = 0)
-parser.add_argument("--level",           type = float, help="contour level output. Default to one-sided 95% CL.", default = 1.64485362695)
+parser.add_argument("--level",           type = float, help="contour level output. Default to one-sided 95%% CL.", default = 1.64485362695)
 parser.add_argument("--useROOT","-r",    help = "use the root interpolation engine instead of mpl", action="store_true", default=False)
 parser.add_argument("--debug","-d",      help = "print extra debugging info", action="store_true", default=False)
 parser.add_argument("--sigmax",          type = float, help="maximum significance in sigmas", default = 5.0)


### PR DESCRIPTION
When calling the help for harvestToContours.py by `harvestToContours.py -h` it raises the error. 
```
ValueError: unsupported format character 'C' (0x43) at index 47
```
Since it misinterprets the % character in line 57. 
This is a fix for the same by replacing the % with a %%.