### PR TITLE
Fix Contour for Mpl based interpolation

### DIFF
--- a/scripts/harvestToContours.py
+++ b/scripts/harvestToContours.py
@@ -642,6 +642,7 @@ def interpolateSurface(modelDict = {}, interpolationFunction = "linear", useROOT
 
             # Creating meshgrid for interpolation
             xymeshgrid = np.meshgrid(xlinspace,ylinspace)
+            xymeshgrid = list(xymeshgrid)
 
             # Optional smoothing given by -s option
             smoothingFactor = 0
@@ -729,6 +730,9 @@ def interpolateSurface(modelDict = {}, interpolationFunction = "linear", useROOT
 
                 graphs[whichContour] = []
                 for contour in contourList:
+                    if len(contour[0]) == 0:
+                        print(f">>> ... WARNING: No contour found for {whichContour} at level {args.level}. Skipping.")
+                        continue
                     graph = ROOT.TGraph(len(contour[0]), contour[0].flatten('C'), contour[1].flatten('C') )
                     if graph.Integral() > args.areaThreshold:
                         graphs[whichContour].append(graph)
@@ -865,12 +869,13 @@ def createGraphsFromArrays(x,y,z,label):
 def getContourPoints(xi,yi,zi,level ):
 
     c = plt.contour(xi,yi,zi, [level])
-    contour = c.collections[0]
+    # contour = c.collections[0]
+    contour = c.allsegs[0]
 
     contourList = []
 
-    for i in range( len(contour.get_paths() ) ):
-        v = contour.get_paths()[i].vertices
+    for i in range( len(contour) ):
+        v = contour[i]
 
         x = v[:,0]
         y = v[:,1]


### PR DESCRIPTION
* Converted xymeshgrid to a list
This prevents the following error
```
    xymeshgrid[1] = xymeshgrid[1] / yScaling
    ~~~~~~~~~~^^^
TypeError: 'tuple' object does not support item assignment
```
* Added a guard to check for no contours
Otherwise root throws an error when empty list is passed to it
* Replaced collections with allsegs
collections are no-longer supported by mpl