### PR TITLE
feat: CMake Improvements for installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ install(DIRECTORY ./macros DESTINATION ${CMAKE_INSTALL_DATADIR}/histfitter
 
 #Copy python files to install location
 install(DIRECTORY ./python/ DESTINATION "${Python3_SITEARCH}/HistFitter")
+file(WRITE "${CMAKE_BINARY_DIR}/HistFitter/__init__.py" "")
+install(FILES "${CMAKE_BINARY_DIR}/HistFitter/__init__.py" DESTINATION "${Python3_SITEARCH}/HistFitter")
 install(PROGRAMS scripts/HistFitter.py
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         RENAME histfitter)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ set(root_components Core;Net;Hist;Graf;Graf3d;Gpad;Tree;Rint;
         Postscript;Matrix;Physics;Gui;RooFitCore;RooFit;RooStats;
         HistFactory;XMLParser;Foam;Minuit)
 
+include(GNUInstallDirs)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 #Require root
 find_package(ROOT 6 REQUIRED ${root_components})
 list(TRANSFORM root_components PREPEND ROOT::)
@@ -60,8 +63,8 @@ install(DIRECTORY ./macros DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter
 install(DIRECTORY ./test DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
 
 #Copy python files to install location
-install(DIRECTORY ./python/ DESTINATION "${CMAKE_INSTALL_PREFIX}/python/histfitter")
-install(DIRECTORY ./scripts/ DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/histfitter" 
+install(DIRECTORY ./python/ DESTINATION "${Python3_SITEARCH}/HistFitter")
+install(DIRECTORY ./scripts/ DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/histfitter"
             USE_SOURCE_PERMISSIONS)
 
 #Copy C++ headers before generating root dictionary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,12 @@ install(DIRECTORY ./python/ DESTINATION "${HISTFITTER_PYTHON_INSTALL_DIR}")
 install(PROGRAMS scripts/HistFitter.py
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         RENAME histfitter)
+
+install( CODE "
+set(INSTALL_DEST \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")
+file(CREATE_LINK \"histfitter\" \"\${INSTALL_DEST}/HistFitter.py\" SYMBOLIC)
+")
+
 install(PROGRAMS
   scripts/GenerateJSONOutput.py
   scripts/GenerateTreeDescriptionFromJSON.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,6 @@ install(DIRECTORY ./macros DESTINATION ${CMAKE_INSTALL_DATADIR}/histfitter
 
 #Copy python files to install location
 install(DIRECTORY ./python/ DESTINATION "${Python3_SITEARCH}/HistFitter")
-file(WRITE "${CMAKE_BINARY_DIR}/HistFitter/__init__.py" "")
-install(FILES "${CMAKE_BINARY_DIR}/HistFitter/__init__.py" DESTINATION "${Python3_SITEARCH}/HistFitter")
 install(PROGRAMS scripts/HistFitter.py
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         RENAME histfitter)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(root_components Core;Net;Hist;Graf;Graf3d;Gpad;Tree;Rint;
 include(GNUInstallDirs)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+set(HISTFITTER_PYTHON_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/python/histfitter")
+configure_file(histfitter_env_setup.sh.in "${CMAKE_CURRENT_BINARY_DIR}/histfitter_env_setup.sh" @ONLY)
+
 #Require root
 find_package(ROOT 6 REQUIRED ${root_components})
 list(TRANSFORM root_components PREPEND ROOT::)
@@ -51,7 +54,7 @@ list(REMOVE_DUPLICATES HistFitter_headers)
 
 #Copy setup scripts
 install(PROGRAMS setup_histfitter.sh DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-install(FILES ./histfitter_env_setup.sh DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/histfitter_env_setup.sh" DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
 #Copy files needed for working directories
 install(FILES ./config/HistFactorySchema.dtd DESTINATION "${CMAKE_INSTALL_DATADIR}/histfitter/config")
@@ -65,10 +68,16 @@ install(DIRECTORY ./macros DESTINATION ${CMAKE_INSTALL_DATADIR}/histfitter
 )
 
 #Copy test files for testing build
-# install(DIRECTORY ./test DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
+option(HISTFITTER_INSTALL_TESTS "Install test files for use with setup_histfitter.sh -t" OFF)
+if(HISTFITTER_INSTALL_TESTS)
+  install(DIRECTORY ./test DESTINATION "${CMAKE_INSTALL_DATADIR}/histfitter"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+  )
+endif()
 
 #Copy python files to install location
-install(DIRECTORY ./python/ DESTINATION "${Python3_SITEARCH}/HistFitter")
+install(DIRECTORY ./python/ DESTINATION "${HISTFITTER_PYTHON_INSTALL_DIR}")
 install(PROGRAMS scripts/HistFitter.py
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         RENAME histfitter)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/install" CACHE PATH "..." FORCE)
 endif()
-set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
 
 #Define equired root components
 set(root_components Core;Net;Hist;Graf;Graf3d;Gpad;Tree;Rint;
@@ -55,20 +54,52 @@ install(PROGRAMS setup_histfitter.sh DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 install(FILES ./histfitter_env_setup.sh DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
 #Copy files needed for working directories
-install(FILES ./config/HistFactorySchema.dtd DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter/config")
-install(DIRECTORY ./analysis DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
-install(DIRECTORY ./macros DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
+install(FILES ./config/HistFactorySchema.dtd DESTINATION "${CMAKE_INSTALL_DATADIR}/histfitter/config")
+install(DIRECTORY ./analysis DESTINATION ${CMAKE_INSTALL_DATADIR}/histfitter
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+)
+install(DIRECTORY ./macros DESTINATION ${CMAKE_INSTALL_DATADIR}/histfitter
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*.pyc" EXCLUDE
+)
 
 #Copy test files for testing build
-install(DIRECTORY ./test DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
+# install(DIRECTORY ./test DESTINATION "${CMAKE_INSTALL_PREFIX}/share/histfitter")
 
 #Copy python files to install location
 install(DIRECTORY ./python/ DESTINATION "${Python3_SITEARCH}/HistFitter")
-install(DIRECTORY ./scripts/ DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/histfitter"
-            USE_SOURCE_PERMISSIONS)
+install(PROGRAMS scripts/HistFitter.py
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        RENAME histfitter)
+install(PROGRAMS
+  scripts/GenerateJSONOutput.py
+  scripts/GenerateTreeDescriptionFromJSON.py
+  scripts/HypoTest.py
+  scripts/PrintFitResult.py
+  scripts/PrintFitResultTex.py
+  scripts/SysTable.py
+  scripts/SysTableTex.py
+  scripts/SystRankingPlot.py
+  scripts/SystRankingPlotMP.py
+  scripts/UpperLimitTable.py
+  scripts/UpperLimitTableTex.py
+  scripts/YieldsTable.py
+  scripts/YieldsTableTex.py
+  scripts/contourPlotter.py
+  scripts/getFinalFullJER.py
+  scripts/harvestHepdataToContours.py
+  scripts/harvestToContours.py
+  scripts/mergeSysTableBreakdown.py
+  scripts/multiplexContours.py
+  scripts/multiplexJSON.py
+  scripts/plotUpDown.py
+  scripts/pull_maker.py
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 #Copy C++ headers before generating root dictionary
-install(FILES ${HistFitter_headers} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/histfitter")
+install(FILES ${HistFitter_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/histfitter")
 
 #Add libraries
 add_library(HistFitter SHARED ${HistFitter_sources})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,3 +121,10 @@ if(MSVC)
 else()
     target_compile_options(HistFitter PRIVATE -Wall -Wextra -Wpedantic)
 endif()
+
+install(CODE "execute_process(COMMAND rm -f
+    \"\${CMAKE_INSTALL_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache\"
+    \"\${CMAKE_INSTALL_PREFIX}/lib/graphviz/config8\"
+    \"\${CMAKE_INSTALL_PREFIX}/lib/gtk-3.0/3.0.0/immodules.cache\"
+    \"\${CMAKE_INSTALL_PREFIX}/share/glib-2.0/schemas/gschemas.compiled\"
+    \"\${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/icon-theme.cache\")")

--- a/README.md
+++ b/README.md
@@ -58,24 +58,26 @@ If you use this option you do not need to clone the source code, and you can ski
 
 ## Build and install
 
-Make your build directory and specify an install directory. You have to point cmake to where the cloned source directory is located.
-```
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=/path/to/install/ /path/to/histfitter/
-make install
-```
-Depending on your cmake version, you may need to add '-B.' in order to get cmake to put the build files into the current directory.
+Configure, build, and install from the source directory. An optional install prefix can be specified; if omitted it defaults to `install/` within the source tree.
 
-HistFitter was originally built and used in the same directory as the source code. If you prefer this option, simply go to the source directory and make the build directory there. This will treat the source code directory `histfitter` as the install location, creating the `install` directory directly there.
 ```
-cd histfitter
-mkdir build
-cd build
-cmake  ..
-make install
+cmake -S . -B build [-DCMAKE_INSTALL_PREFIX=/path/to/install]
+cmake --build build
+cmake --install build
 ```
-This will create an install directory with the installed libraries as well as other files needed at runtime.
+
+This will create an install directory with the installed libraries and all other files needed at runtime. The install layout within the prefix is:
+
+- `bin/` — `histfitter` entry point and utility scripts
+- `lib/` — shared library
+- `include/histfitter/` — C++ headers
+- `python/histfitter/` — Python library (path baked into `histfitter_env_setup.sh` at configure time)
+- `share/histfitter/` — data files: schema, analysis examples, macros
+
+Test files are not installed by default. To include them (required for the `-t` flag in `setup_histfitter.sh`):
+```
+cmake -S . -B build -DHISTFITTER_INSTALL_TESTS=ON
+```
 
 
 ## Setup
@@ -143,7 +145,7 @@ pip install pyhf['jax']
 - `data`: Contains data root files, provided externally, used to create workspaces for analysis
 
 ## Tests and troubleshooting
-To check that everything is working properly, you can run the tests. This requires you to have the pytest python module installed. Run the setup script with the `-t` flag.
+To check that everything is working properly, you can run the tests. This requires you to have the pytest python module installed. First ensure HistFitter was built with `-DHISTFITTER_INSTALL_TESTS=ON`, then run the setup script with the `-t` flag.
 ```
 source /path/to/install/bin/setup_histfitter.sh -t
 ```

--- a/histfitter_env_setup.sh.in
+++ b/histfitter_env_setup.sh.in
@@ -63,7 +63,7 @@ export HISTFITTER_VERSION=$VERSION
 if [ ! -z "${BASH_VERSION}" ]; then
   #Find location of this script in the install area
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-elif [ ! -z "${ZSH_VERSION}" ]; then 
+elif [ ! -z "${ZSH_VERSION}" ]; then
   #Find location of this script in the install area
   SCRIPT_DIR="${0:A:h}"
 else
@@ -74,13 +74,12 @@ echo "Adding HistFitter paths: ROOT_INCLUDE_PATH, PATH, LD_LIBRARY_PATH, PYTHONP
 
 #Update paths
 export ROOT_INCLUDE_PATH="$ROOT_INCLUDE_PATH:$SCRIPT_DIR/../include/histfitter"
-export PATH="$PATH:$SCRIPT_DIR/histfitter"
+export PATH="$PATH:$SCRIPT_DIR"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SCRIPT_DIR/../lib"
 
 # PYTHONPATH contains all directories that are used for 'import bla' commands
-# Must prepend so as to catch python/cmdLineUtils.py before ROOT installation's
-export PYTHONPATH="$SCRIPT_DIR/../python/histfitter:$PYTHONPATH"
-export PYTHONPATH="$SCRIPT_DIR/histfitter:$PYTHONPATH"
+# Must prepend so as to catch histfitter modules before ROOT installation's
+export PYTHONPATH="@HISTFITTER_PYTHON_INSTALL_DIR@:$PYTHONPATH"
 
 # Hack for ssh from mac
 export LC_ALL=C

--- a/setup_histfitter.sh
+++ b/setup_histfitter.sh
@@ -77,8 +77,12 @@ fi
 
 #Copy test files if specified
 if [ $test = true ]; then
-  echo "Copying /test folder to $HISTFITTER_WORKDIR/test.";
-  cp -r "$SCRIPT_DIR/../share/histfitter/test" "$HISTFITTER_WORKDIR";
+  if [ ! -d "$SCRIPT_DIR/../share/histfitter/test" ]; then
+    echo "Warning: test directory not found in install. Was HistFitter built with -DHISTFITTER_INSTALL_TESTS=ON?";
+  else
+    echo "Copying /test folder to $HISTFITTER_WORKDIR/test.";
+    cp -r "$SCRIPT_DIR/../share/histfitter/test" "$HISTFITTER_WORKDIR";
+  fi
 fi
 
 #Removing module.modulemap


### PR DESCRIPTION
This MR updates the build and installation procedure of HistFitter to better align with standard CMake and Python practices, while also performing general cleanup of unused components and installed artifacts. Primarily motivated/driven by conda-forge packaging: https://github.com/conda-forge/histfitter-feedstock/tree/b79db99/recipe/patches

## Changes

### Build and installation

* Adopt `GNUInstallDirs` to use standard installation locations: `${CMAKE_INSTALL_BINDIR}`, `${CMAKE_INSTALL_DATADIR}`, `${CMAKE_INSTALL_INCLUDEDIR}`, etc.
* Remove hardcoded install paths (e.g. custom `lib/` handling)
* Relocate shared resources (config, analysis, macros) to:`${CMAKE_INSTALL_DATADIR}/histfitter`
* Install C++ headers to `${CMAKE_INSTALL_INCLUDEDIR}/histfitter`

### Python integration

* Install Python modules into `Python3_SITEARCH` instead of a custom prefix
* Ensure `HistFitter` is a proper Python package by installing a generated `__init__.py`
* Replace directory-based script installation with explicit `install(PROGRAMS)`:
  * Provide a `histfitter` CLI entry point
  * Install all auxiliary scripts into `${CMAKE_INSTALL_BINDIR}`

### Cleanup of installed content

* Exclude Python cache files from installation: `__pycache__/`, `*.pyc`
* Disable installation of the `test/` directory
* Remove extraneous cache files from third-party components at install time (e.g. GTK, glib, graphviz)

## Motivation

These changes aim to:

* Align HistFitter with common CMake and Python packaging conventions
* Improve usability in standard Python environments (including virtual environments)
* Reduce the installed footprint by avoiding unnecessary files and caches
* Remove unused code paths to simplify maintenance

## Notes

* No intended changes to physics results or statistical behaviour
* Changes are limited to build system, installation layout, and code cleanup
